### PR TITLE
fix: added commits from 1st June to 30th June 2026

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,10 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence.
 
-* @ruchamahabal
+hrms/hr/ @ruchamahabal @asmitahase
+hrms/payroll/ @ruchamahabal @AyshaHakeem @iamkhanraheel
+
+frontend/ @ruchamahabal @asmitahase
+roster/ @ruchamahabal @asmitahase
+
+.github/ @asmitahase

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -40,8 +40,6 @@ jobs:
           
       - name: Set Branch
         run: |
-          export APPS_JSON_PATH='${{ github.workspace }}/.github/helper/apps.json'
-          echo "APPS_JSON_BASE64=$(cat $APPS_JSON_PATH | base64 -w 0)" >> $GITHUB_ENV
           echo "FRAPPE_BRANCH=version-15" >> $GITHUB_ENV
 
       - name: Set Image Tag
@@ -63,4 +61,5 @@ jobs:
             ghcr.io/${{ github.repository }}:${{ env.IMAGE_TAG }}
           build-args: |
             "FRAPPE_BRANCH=${{ env.FRAPPE_BRANCH }}"
-            "APPS_JSON_BASE64=${{ env.APPS_JSON_BASE64 }}"
+          secret-files: |
+            apps_json=${{ github.workspace }}/.github/helper/apps.json

--- a/frontend/src/components/EmployeeAdvanceItem.vue
+++ b/frontend/src/components/EmployeeAdvanceItem.vue
@@ -60,6 +60,7 @@ const props = defineProps({
 
 const colorMap = {
 	Paid: "green",
+	"Partially Paid": "blue",
 	Unpaid: "orange",
 	Claimed: "blue",
 	Returned: "gray",

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -65,13 +65,15 @@ const registerServiceWorker = async () => {
 		let serviceWorkerURL = "/assets/hrms/frontend/sw.js"
 		let config = ""
 
-		try {
-			config = await window.frappePushNotification.fetchWebConfig()
-			serviceWorkerURL = `${serviceWorkerURL}?config=${encodeURIComponent(
-				JSON.stringify(config)
-			)}`
-		} catch (err) {
-			console.error("Failed to fetch FCM config", err)
+		if (window.frappe?.boot?.push_relay_server_url) {
+			try {
+				config = await window.frappePushNotification.fetchWebConfig()
+				serviceWorkerURL = `${serviceWorkerURL}?config=${encodeURIComponent(
+					JSON.stringify(config)
+				)}`
+			} catch (err) {
+				console.error("Failed to fetch FCM config", err)
+			}
 		}
 
 		navigator.serviceWorker
@@ -121,8 +123,8 @@ router.beforeEach(async (to, _, next) => {
 		// password reset page is outside the PWA scope
 		if (to.path === "/update-password") {
 			return next(false)
-		} else if (to.name !== "Login") {
-			next({ name: "Login" })
+		} else if (!["Login", "ForgotPassword"].includes(to.name)) {
+			return next({ name: "Login" })
 		}
 	}
 
@@ -135,7 +137,7 @@ router.beforeEach(async (to, _, next) => {
 			employeeResource?.data?.user_id !== userResource.data.name
 		) {
 			next({ name: "InvalidEmployee" })
-		} else if (to.name === "Login") {
+		} else if (["Login", "ForgotPassword"].includes(to.name)) {
 			next({ name: "Home" })
 		} else {
 			next()

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -53,6 +53,11 @@ const routes = [
 		component: () => import("@/views/Login.vue"),
 	},
 	{
+		path: "/forgot-password",
+		name: "ForgotPassword",
+		component: () => import("@/views/ForgotPassword.vue"),
+	},
+	{
 		path: "/profile",
 		name: "Profile",
 		component: () => import("@/views/Profile.vue"),
@@ -66,6 +71,11 @@ const routes = [
 		path: "/settings",
 		name: "Settings",
 		component: () => import("@/views/AppSettings.vue"),
+	},
+	{
+		path: "/change-password",
+		name: "ChangePassword",
+		component: () => import("@/views/ChangePassword.vue"),
 	},
 	{
 		path: "/invalid-employee",

--- a/frontend/src/views/ForgotPassword.vue
+++ b/frontend/src/views/ForgotPassword.vue
@@ -1,0 +1,116 @@
+<template>
+	<ion-page>
+		<ion-content :fullscreen="true">
+			<div class="flex flex-col h-full w-full">
+				<div class="w-full h-full bg-white sm:w-96 flex flex-col">
+					<header
+						class="flex flex-row bg-white shadow-sm py-4 px-3 items-center sticky top-0 z-[1000]"
+					>
+						<Button
+							variant="ghost"
+							class="!pl-0 hover:bg-white"
+							@click="goBack"
+						>
+							<FeatherIcon name="chevron-left" class="h-5 w-5" />
+						</Button>
+						<h2 class="text-xl font-semibold text-gray-900">{{ __("Reset Password") }}</h2>
+					</header>
+
+					<div class="bg-white grow overflow-y-auto">
+						<form class="flex flex-col space-y-4 p-4" @submit.prevent="sendPasswordReset">
+							<p class="text-sm leading-5 text-gray-600">
+								{{ __("Enter your email address and we'll send you a link to reset your password.") }}
+							</p>
+							<Input
+								:label="__('Email') + ' *'"
+								type="email"
+								placeholder="johndoe@mail.com"
+								v-model="email"
+								autocomplete="username"
+								required
+							/>
+						</form>
+					</div>
+
+					<div
+						class="px-4 pt-4 pb-4 standalone:pb-safe-bottom sm:w-96 bg-white sticky bottom-0 w-full drop-shadow-xl z-40 border-t rounded-t-lg"
+					>
+						<ErrorMessage class="mb-2" :message="errorMessage" />
+						<Button
+							class="w-full rounded py-5 text-base disabled:bg-gray-700 disabled:text-white"
+							:loading="forgotPasswordResource.loading"
+							variant="solid"
+							@click="sendPasswordReset"
+						>
+							{{ __("Send Reset Link") }}
+						</Button>
+					</div>
+				</div>
+			</div>
+		</ion-content>
+	</ion-page>
+</template>
+
+<script setup>
+import { IonPage, IonContent } from "@ionic/vue"
+import { useRoute, useRouter } from "vue-router"
+import { FeatherIcon, toast, createResource, Input, ErrorMessage, Button } from "frappe-ui"
+
+import { inject, ref } from "vue"
+
+const __ = inject("$translate")
+const route = useRoute()
+const router = useRouter()
+
+const email = ref(Array.isArray(route.query.email) ? route.query.email[0] : route.query.email || "")
+const errorMessage = ref("")
+
+const forgotPasswordResource = createResource({
+	url: "frappe.core.doctype.user.user.reset_password",
+	method: "POST",
+	onSuccess() {
+		toast({
+			title: __("Success"),
+			text: __("Password reset link has been sent to your email."),
+			icon: "check-circle",
+			position: "bottom-center",
+			iconClasses: "text-green-500",
+		})
+		errorMessage.value = ""
+		router.replace({ name: "Login" })
+	},
+	onError(error) {
+		errorMessage.value = error.messages?.[0] || __("Failed to send reset link")
+	},
+})
+
+function isValidEmail(value) {
+	return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)
+}
+
+function goBack() {
+	if (window.history.state?.back) {
+		router.back()
+		return
+	}
+
+	router.replace({ name: "Login" })
+}
+
+function sendPasswordReset() {
+	const emailValue = (email.value || "").trim()
+
+	if (!emailValue) {
+		errorMessage.value = __("Please enter your email address")
+		return
+	}
+
+	if (!isValidEmail(emailValue)) {
+		errorMessage.value = __("Please enter a valid email address")
+		return
+	}
+
+	errorMessage.value = ""
+	forgotPasswordResource.submit({ user: emailValue })
+}
+</script>

--- a/frontend/src/views/employee_advance/List.vue
+++ b/frontend/src/views/employee_advance/List.vue
@@ -34,12 +34,13 @@ const EMPLOYEE_ADVANCE_FIELDS = [
 const STATUS_FILTER_OPTIONS = [
 	"Draft",
 	"Paid",
+	"Partially Paid",
 	"Unpaid",
 	"Claimed",
 	"Returned",
 	"Partly Claimed and Returned",
 	"Cancelled",
-] // __("Draft"), __("Paid"), __("Unpaid"), __("Claimed"), __("Returned"), __("Partly Claimed and Returned"), __("Cancelled")
+] // __("Draft"), __("Paid"), __("Partially Paid"), __("Unpaid"), __("Claimed"), __("Returned"), __("Partly Claimed and Returned"), __("Cancelled")
 const FILTER_CONFIG = [
 	{
 		fieldname: "status",

--- a/hrms/api/__init__.py
+++ b/hrms/api/__init__.py
@@ -78,6 +78,17 @@ def get_all_employees() -> list[dict]:
 	)
 
 
+@frappe.whitelist()
+def get_reports_to_employee_name(employee: str) -> str:
+	reports_to = frappe.db.get_value(
+		"Employee", {"user_id": frappe.session.user, "status": "Active"}, "reports_to"
+	)
+	if not reports_to or reports_to != employee:
+		frappe.throw(_("Not permitted"), frappe.PermissionError)
+
+	return frappe.db.get_value("Employee", employee, "employee_name") or ""
+
+
 def get_current_employee() -> str:
 	employee = get_current_employee_info().get("name")
 	if not employee:
@@ -92,6 +103,7 @@ def get_hr_settings() -> dict:
 	return frappe._dict(
 		allow_employee_checkin_from_mobile_app=settings.allow_employee_checkin_from_mobile_app,
 		allow_geolocation_tracking=settings.allow_geolocation_tracking,
+		prevent_self_leave_approval=settings.prevent_self_leave_approval,
 	)
 
 
@@ -273,6 +285,8 @@ def get_filters(
 
 @frappe.whitelist()
 def get_shift_request_approvers(employee: str) -> str | list[str]:
+	frappe.has_permission("Employee", "read", employee, throw=True)
+
 	shift_request_approver, department = frappe.get_cached_value(
 		"Employee",
 		employee,
@@ -281,6 +295,7 @@ def get_shift_request_approvers(employee: str) -> str | list[str]:
 
 	department_approvers = []
 	if department:
+		frappe.has_permission("Department", "read", department, throw=True)
 		department_approvers = get_department_approvers(department, "shift_request_approver")
 		if not shift_request_approver:
 			shift_request_approver = frappe.db.get_value(
@@ -407,6 +422,8 @@ def get_holidays_for_employee(employee: str) -> list[dict]:
 	if not holiday_list:
 		return []
 
+	frappe.has_permission("Holiday List", "read", holiday_list, throw=True)
+
 	Holiday = frappe.qb.DocType("Holiday")
 	holidays = (
 		frappe.qb.from_(Holiday)
@@ -423,6 +440,7 @@ def get_holidays_for_employee(employee: str) -> list[dict]:
 
 @frappe.whitelist()
 def get_leave_approval_details(employee: str) -> dict:
+	frappe.has_permission("Employee", "read", employee, throw=True)
 	leave_approver, department = frappe.get_cached_value(
 		"Employee",
 		employee,
@@ -430,6 +448,7 @@ def get_leave_approval_details(employee: str) -> dict:
 	)
 
 	if not leave_approver and department:
+		frappe.has_permission("Department", "read", department, throw=True)
 		leave_approver = frappe.db.get_value(
 			"Department Approver",
 			{"parent": department, "parentfield": "leave_approvers", "idx": 1},
@@ -486,6 +505,7 @@ def get_leave_types(employee: str, date: str) -> list:
 
 	date = date or getdate()
 
+	# Get leave details validate leave access internally
 	leave_details = get_leave_details(employee, date)
 	leave_types = list(leave_details["leave_allocation"].keys()) + leave_details["lwps"]
 
@@ -506,6 +526,7 @@ def get_expense_claims(
 		"`tabExpense Claim`.posting_date",
 		"`tabExpense Claim`.employee",
 		"`tabExpense Claim`.employee_name",
+		"`tabExpense Claim`.currency",
 		"`tabExpense Claim`.approval_status",
 		"`tabExpense Claim`.status",
 		"`tabExpense Claim`.expense_approver",
@@ -514,7 +535,7 @@ def get_expense_claims(
 		"`tabExpense Claim`.company",
 		"`tabExpense Claim`.creation",
 		"`tabExpense Claim Detail`.expense_type",
-		"count(`tabExpense Claim Detail`.expense_type) as total_expenses",
+		{"COUNT": "`tabExpense Claim Detail`.expense_type", "as": "total_expenses"},
 	]
 
 	if workflow_state_field := get_workflow_state_field("Expense Claim"):
@@ -598,6 +619,7 @@ def get_expense_claim_types() -> list[dict]:
 
 @frappe.whitelist()
 def get_expense_approval_details(employee: str) -> dict:
+	frappe.has_permission("Employee", "read", employee, throw=True)
 	expense_approver, department = frappe.get_cached_value(
 		"Employee",
 		employee,
@@ -605,6 +627,7 @@ def get_expense_approval_details(employee: str) -> dict:
 	)
 
 	if not expense_approver and department:
+		frappe.has_permission("Department", "read", department, throw=True)
 		expense_approver = frappe.db.get_value(
 			"Department Approver",
 			{"parent": department, "parentfield": "expense_approvers", "idx": 1},
@@ -648,17 +671,12 @@ def get_employee_advance_balance() -> list[dict]:
 			& (Advance.paid_amount)
 			& (Advance.employee == employee)
 			# don't need claimed & returned advances, only partly or completely paid ones
-			& (Advance.status.isin(["Paid", "Unpaid"]))
+			& (Advance.status.isin(["Paid", "Partially Paid", "Unpaid"]))
 		)
 		.orderby(Advance.posting_date, order=Order.desc)
 	).run(as_dict=True)
 
 	return advances
-
-
-@frappe.whitelist()
-def get_advance_account(company: str) -> str | None:
-	return frappe.db.get_value("Company", company, "default_employee_advance_account", cache=True)
 
 
 # Company
@@ -694,6 +712,7 @@ def get_currency_symbols() -> dict:
 
 @frappe.whitelist()
 def get_company_cost_center_and_expense_account(company: str) -> dict:
+	frappe.has_permission("Company", "read", company, throw=True)
 	return frappe.db.get_value(
 		"Company", company, ["cost_center", "default_expense_claim_payable_account"], as_dict=True
 	)
@@ -727,7 +746,9 @@ def get_attachments(dt: str, dn: str):
 
 
 @frappe.whitelist()
-def upload_base64_file(content, filename, dt=None, dn=None, fieldname=None):
+def upload_base64_file(
+	content: str, filename: str, dt: str | None = None, dn: str | None = None, fieldname: str | None = None
+):
 	import base64
 	import io
 	from mimetypes import guess_type
@@ -752,6 +773,8 @@ def upload_base64_file(content, filename, dt=None, dn=None, fieldname=None):
 	else:
 		file_content = decoded_content
 
+	frappe.has_permission(dt, "write", dn, throw=True)
+
 	return frappe.get_doc(
 		{
 			"doctype": "File",
@@ -768,21 +791,26 @@ def upload_base64_file(content, filename, dt=None, dn=None, fieldname=None):
 
 @frappe.whitelist()
 def delete_attachment(filename: str):
+	attached_to_doctype, attached_to_name = frappe.db.get_value(
+		"File", filename, ["attached_to_doctype", "attached_to_name"]
+	)
+	if attached_to_doctype and attached_to_name:
+		frappe.has_permission(attached_to_doctype, "write", attached_to_name, throw=True)
 	frappe.delete_doc("File", filename)
 
 
 @frappe.whitelist()
-def download_salary_slip(name: str):
+def _download_pdf(doctype: str, docname: str) -> str:
 	import base64
 
 	from frappe.utils.print_format import download_pdf
 
-	default_print_format = frappe.get_meta("Salary Slip").default_print_format or "Standard"
+	default_print_format = frappe.get_meta(doctype).default_print_format or "Standard"
 
 	try:
-		download_pdf("Salary Slip", name, format=default_print_format)
-	except Exception:
-		frappe.throw(_("Failed to download Salary Slip PDF"))
+		download_pdf(doctype, docname, format=default_print_format)
+	except Exception as e:
+		frappe.throw(_("Failed to download PDF: {0}").format(str(e)))
 
 	base64content = base64.b64encode(frappe.local.response.filecontent)
 	content_type = frappe.local.response.type

--- a/hrms/controllers/employee_boarding_controller.py
+++ b/hrms/controllers/employee_boarding_controller.py
@@ -75,20 +75,20 @@ class EmployeeBoardingController(Document):
 
 			users = [activity.user] if activity.user else []
 			if activity.role:
-				user_list = frappe.db.sql_list(
-					"""
-					SELECT
-						DISTINCT(has_role.parent)
-					FROM
-						`tabHas Role` has_role
-							LEFT JOIN `tabUser` user
-								ON has_role.parent = user.name
-					WHERE
-						has_role.parenttype = 'User'
-							AND user.enabled = 1
-							AND has_role.role = %s
-				""",
-					activity.role,
+				has_role = frappe.qb.DocType("Has Role")
+				user = frappe.qb.DocType("User")
+				user_list = (
+					frappe.qb.from_(has_role)
+					.left_join(user)
+					.on(has_role.parent == user.name)
+					.select(has_role.parent)
+					.distinct()
+					.where(
+						(has_role.parenttype == "User")
+						& (user.enabled == 1)
+						& (has_role.role == activity.role)
+					)
+					.run(pluck="parent")
 				)
 				users = unique(users + user_list)
 
@@ -156,7 +156,8 @@ class EmployeeBoardingController(Document):
 
 
 @frappe.whitelist()
-def get_onboarding_details(parent, parenttype):
+def get_onboarding_details(parent: str, parenttype: str):
+	frappe.has_permission(parenttype, "read", parent, throw=True)
 	return frappe.get_all(
 		"Employee Boarding Activity",
 		fields=[

--- a/hrms/hr/doctype/appraisal/appraisal.py
+++ b/hrms/hr/doctype/appraisal/appraisal.py
@@ -14,6 +14,43 @@ from hrms.payroll.utils import sanitize_expression
 
 
 class Appraisal(Document, AppraisalMixin):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from hrms.hr.doctype.appraisal_goal.appraisal_goal import AppraisalGoal
+		from hrms.hr.doctype.appraisal_kra.appraisal_kra import AppraisalKRA
+		from hrms.hr.doctype.employee_feedback_rating.employee_feedback_rating import EmployeeFeedbackRating
+
+		amended_from: DF.Link | None
+		appraisal_cycle: DF.Link
+		appraisal_kra: DF.Table[AppraisalKRA]
+		appraisal_template: DF.Link | None
+		avg_feedback_score: DF.Float
+		company: DF.Link
+		department: DF.Link | None
+		designation: DF.Link | None
+		employee: DF.Link
+		employee_image: DF.AttachImage | None
+		employee_name: DF.Data | None
+		end_date: DF.Date | None
+		final_score: DF.Float
+		goal_score_percentage: DF.Float
+		goals: DF.Table[AppraisalGoal]
+		naming_series: DF.Literal["HR-APR-.YYYY.-"]
+		rate_goals_manually: DF.Check
+		reflections: DF.TextEditor | None
+		remarks: DF.Text | None
+		self_ratings: DF.Table[EmployeeFeedbackRating]
+		self_score: DF.Float
+		start_date: DF.Date | None
+		total_score: DF.Float
+	# end: auto-generated types
+
 	def validate(self):
 		self.set_kra_evaluation_method()
 
@@ -210,7 +247,7 @@ class Appraisal(Document, AppraisalMixin):
 		self.final_score = flt(final_score, self.precision("final_score"))
 
 	@frappe.whitelist()
-	def add_feedback(self, feedback, feedback_ratings):
+	def add_feedback(self, feedback: str, feedback_ratings: list) -> Document:
 		feedback = frappe.get_doc(
 			{
 				"doctype": "Employee Performance Feedback",
@@ -269,7 +306,8 @@ class Appraisal(Document, AppraisalMixin):
 
 
 @frappe.whitelist()
-def get_feedback_history(employee, appraisal):
+def get_feedback_history(employee: str, appraisal: str) -> dict:
+	frappe.has_permission("Appraisal", "read", appraisal, throw=True)
 	data = frappe._dict()
 	data.feedback_history = frappe.get_list(
 		"Employee Performance Feedback",
@@ -323,7 +361,9 @@ def get_feedback_history(employee, appraisal):
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
-def get_kras_for_employee(doctype, txt, searchfield, start, page_len, filters):
+def get_kras_for_employee(
+	doctype: str, txt: str, searchfield: str, start: int, page_len: int, filters: dict
+) -> tuple[tuple[str]]:
 	appraisal = frappe.db.get_value(
 		"Appraisal",
 		{

--- a/hrms/hr/doctype/appraisal_cycle/appraisal_cycle.py
+++ b/hrms/hr/doctype/appraisal_cycle/appraisal_cycle.py
@@ -9,6 +9,31 @@ from frappe.query_builder.terms import SubQuery
 
 
 class AppraisalCycle(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from hrms.hr.doctype.appraisee.appraisee import Appraisee
+
+		appraisees: DF.Table[Appraisee]
+		branch: DF.Link | None
+		calculate_final_score_based_on_formula: DF.Check
+		company: DF.Link
+		cycle_name: DF.Data
+		department: DF.Link | None
+		description: DF.TextEditor | None
+		designation: DF.Link | None
+		end_date: DF.Date
+		final_score_formula: DF.Code | None
+		kra_evaluation_method: DF.Literal["Automated Based on Goal Progress", "Manual Rating"]
+		start_date: DF.Date
+		status: DF.Literal["Not Started", "In Progress", "Completed"]
+	# end: auto-generated types
+
 	def onload(self):
 		self.set_onload("appraisals_created", self.check_if_appraisals_exist())
 
@@ -37,6 +62,7 @@ class AppraisalCycle(Document):
 	@frappe.whitelist()
 	def set_employees(self):
 		"""Pull employees in appraisee list based on selected filters"""
+		self.check_permission("write")
 		employees = self.get_employees_for_appraisal()
 		appraisal_templates = self.get_appraisal_template_map()
 
@@ -209,6 +235,7 @@ def validate_active_appraisal_cycle(appraisal_cycle: str) -> None:
 
 @frappe.whitelist()
 def get_appraisal_cycle_summary(cycle_name: str) -> dict:
+	frappe.has_permission("Appraisal Cycle", "read", cycle_name, throw=True)
 	summary = frappe._dict()
 
 	summary["appraisees"] = frappe.db.count(
@@ -248,10 +275,17 @@ def get_employees_without_goals(cycle_name: str) -> int:
 	return goals_missing[0].count
 
 
-def get_employees_without_feedback(cycle_name: str) -> int:
+@frappe.whitelist()
+def get_employees_without_feedback(cycle_name: str | None = None) -> int:
 	Feedback = frappe.qb.DocType("Employee Performance Feedback")
 	Appraisal = frappe.qb.DocType("Appraisal")
 	count = Count("*").as_("count")
+	if not cycle_name:
+		cycle_name = frappe.get_value(
+			"Appraisal Cycle", {"status": "In Progress"}, order_by="start_date desc"
+		)
+
+	frappe.has_permission("Appraisal Cycle", "read", cycle_name, throw=True)
 
 	filtered_records = SubQuery(
 		frappe.qb.from_(Feedback)

--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -2,12 +2,16 @@
 # License: GNU General Public License v3. See license.txt
 
 
+from datetime import date
+
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.query_builder.terms import ValueWrapper
 from frappe.utils import (
 	add_days,
 	cint,
+	create_batch,
 	cstr,
 	format_date,
 	get_datetime,
@@ -15,14 +19,15 @@ from frappe.utils import (
 	getdate,
 	nowdate,
 )
+from frappe.utils.background_jobs import get_job
 
 import hrms
 from hrms.hr.doctype.shift_assignment.shift_assignment import has_overlapping_timings
 from hrms.hr.utils import (
-	get_holiday_dates_for_employee,
 	get_holidays_for_employee,
 	validate_active_employee,
 )
+from hrms.utils.holiday_list import get_holiday_dates_between_range
 
 
 class DuplicateAttendanceError(frappe.ValidationError):
@@ -34,6 +39,38 @@ class OverlappingShiftAttendanceError(frappe.ValidationError):
 
 
 class Attendance(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		actual_overtime_duration: DF.Float
+		amended_from: DF.Link | None
+		attendance_date: DF.Date
+		attendance_request: DF.Link | None
+		company: DF.Link
+		department: DF.Link | None
+		early_exit: DF.Check
+		employee: DF.Link
+		employee_name: DF.Data | None
+		half_day_status: DF.Literal["", "Present", "Absent"]
+		in_time: DF.Datetime | None
+		late_entry: DF.Check
+		leave_application: DF.Link | None
+		leave_type: DF.Link | None
+		modify_half_day_status: DF.Check
+		naming_series: DF.Literal["HR-ATT-.YYYY.-"]
+		out_time: DF.Datetime | None
+		overtime_type: DF.Link | None
+		shift: DF.Link | None
+		standard_working_hours: DF.Float
+		status: DF.Literal["", "Present", "Absent", "On Leave", "Half Day", "Work From Home"]
+		working_hours: DF.Float
+	# end: auto-generated types
+
 	def before_insert(self):
 		if self.half_day_status == "":
 			self.half_day_status = None
@@ -41,12 +78,7 @@ class Attendance(Document):
 	def validate(self):
 		from erpnext.controllers.status_updater import validate_status
 
-	def validate(self):
-		from erpnext.controllers.status_updater import validate_status
-
-		validate_status(
-			self.status, ["Present", "Absent", "On Leave", "Half Day", "Work From Home"]
-		)
+		validate_status(self.status, ["Present", "Absent", "On Leave", "Half Day", "Work From Home"])
 		validate_active_employee(self.employee)
 		self.validate_attendance_date()
 		self.validate_duplicate_record()
@@ -57,6 +89,9 @@ class Attendance(Document):
 	def on_cancel(self):
 		self.unlink_attendance_from_checkins()
 
+	def validate_attendance_date(self):
+		date_of_joining = frappe.db.get_value("Employee", self.employee, "date_of_joining")
+
 		if date_of_joining and getdate(self.attendance_date) < getdate(date_of_joining):
 			frappe.throw(
 				_("Attendance date {0} can not be less than employee {1}'s joining date: {2}").format(
@@ -66,19 +101,19 @@ class Attendance(Document):
 				)
 			)
 
-		if date_of_joining and getdate(self.attendance_date) < getdate(date_of_joining):
-			frappe.throw(
-				_(
-					"Attendance date {0} can not be less than employee {1}'s joining date: {2}"
-				).format(
-					frappe.bold(format_date(self.attendance_date)),
-					frappe.bold(self.employee),
-					frappe.bold(format_date(date_of_joining)),
-				)
-			)
-
 	def validate_duplicate_record(self):
 		duplicate = self.get_duplicate_attendance_record()
+
+		if duplicate:
+			frappe.throw(
+				_("Attendance for employee {0} is already marked for the date {1}: {2}").format(
+					frappe.bold(self.employee),
+					frappe.bold(format_date(self.attendance_date)),
+					get_link_to_form("Attendance", duplicate),
+				),
+				title=_("Duplicate Attendance"),
+				exc=DuplicateAttendanceError,
+			)
 
 	def get_duplicate_attendance_record(self) -> str | None:
 		Attendance = frappe.qb.DocType("Attendance")
@@ -108,15 +143,6 @@ class Attendance(Document):
 				)
 			)
 
-		if self.shift:
-			query = query.where(
-				((Attendance.shift.isnull()) | (Attendance.shift == ""))
-				| (
-					((Attendance.shift.isnotnull()) | (Attendance.shift != ""))
-					& (Attendance.shift == self.shift)
-				)
-			)
-
 		duplicate = query.run(pluck=True)
 
 		return duplicate[0] if duplicate else None
@@ -126,9 +152,7 @@ class Attendance(Document):
 
 		if attendance:
 			frappe.throw(
-				_(
-					"Attendance for employee {0} is already marked for an overlapping shift {1}: {2}"
-				).format(
+				_("Attendance for employee {0} is already marked for an overlapping shift {1}: {2}").format(
 					frappe.bold(self.employee),
 					frappe.bold(attendance.shift),
 					get_link_to_form("Attendance", attendance.name),
@@ -141,67 +165,28 @@ class Attendance(Document):
 		if not self.shift:
 			return {}
 
+		Attendance = frappe.qb.DocType("Attendance")
+		same_date_attendance = (
+			frappe.qb.from_(Attendance)
+			.select(Attendance.name, Attendance.shift)
+			.where(
+				(Attendance.employee == self.employee)
+				& (Attendance.docstatus < 2)
+				& (Attendance.attendance_date == self.attendance_date)
+				& (Attendance.shift != self.shift)
+				& (Attendance.name != self.name)
+			)
+		).run(as_dict=True)
+
 		for d in same_date_attendance:
 			if has_overlapping_timings(self.shift, d.shift):
 				return d
 
 		return {}
 
-		for d in same_date_attendance:
-			if has_overlapping_timings(self.shift, d.shift):
-				return d
-
-	def check_leave_record(self):
-		LeaveApplication = frappe.qb.DocType("Leave Application")
-		leave_record = (
-			frappe.qb.from_(LeaveApplication)
-			.select(
-				LeaveApplication.leave_type,
-				LeaveApplication.half_day,
-				LeaveApplication.half_day_date,
-				LeaveApplication.name,
-			)
-			.where(
-				(LeaveApplication.employee == self.employee)
-				& (self.attendance_date >= LeaveApplication.from_date)
-				& (self.attendance_date <= LeaveApplication.to_date)
-				& (LeaveApplication.status == "Approved")
-				& (LeaveApplication.docstatus == 1)
-			)
-		).run(as_dict=True)
-
-		if leave_record:
-			for d in leave_record:
-				self.leave_type = d.leave_type
-				self.leave_application = d.name
-				if d.half_day_date == getdate(self.attendance_date):
-					self.status = "Half Day"
-					frappe.msgprint(
-						_("Employee {0} on Half day on {1}").format(
-							self.employee, format_date(self.attendance_date)
-						)
-					)
-				else:
-					self.status = "On Leave"
-					frappe.msgprint(
-						_("Employee {0} is on Leave on {1}").format(
-							self.employee, format_date(self.attendance_date)
-						)
-					)
-
-		if self.status in ("On Leave", "Half Day"):
-			if not leave_record:
-				self.modify_half_day_status = 0
-				self.half_day_status = "Absent"
-				frappe.msgprint(
-					_("No leave record found for employee {0} on {1}").format(
-						self.employee, format_date(self.attendance_date)
-					),
-					alert=1,
-				)
-		elif self.leave_type:
-			self.leave_type = None
-			self.leave_application = None
+	def validate_employee_status(self):
+		if frappe.db.get_value("Employee", self.employee, "status") == "Inactive":
+			frappe.throw(_("Cannot mark attendance for an Inactive employee {0}").format(self.employee))
 
 	def check_leave_record(self):
 		LeaveApplication = frappe.qb.DocType("Leave Application")
@@ -256,14 +241,14 @@ class Attendance(Document):
 			self.leave_application = None
 
 	def validate_employee(self):
-		emp = frappe.db.sql(
-			"select name from `tabEmployee` where name = %s and status = 'Active'",
-			self.employee,
-		)
+		Employee = frappe.qb.DocType("Employee")
+		emp = (
+			frappe.qb.from_(Employee)
+			.select(Employee.name)
+			.where((Employee.name == self.employee) & (Employee.status == "Active"))
+		).run()
 		if not emp:
-			frappe.throw(
-				_("Employee {0} is not active or does not exist").format(self.employee)
-			)
+			frappe.throw(_("Employee {0} is not active or does not exist").format(self.employee))
 
 	def unlink_attendance_from_checkins(self):
 		EmployeeCheckin = frappe.qb.DocType("Employee Checkin")
@@ -284,10 +269,7 @@ class Attendance(Document):
 
 			frappe.msgprint(
 				msg=_("Unlinked Attendance record from Employee Checkins: {}").format(
-					", ".join(
-						get_link_to_form("Employee Checkin", log.name)
-						for log in linked_logs
-					)
+					", ".join(get_link_to_form("Employee Checkin", log.name) for log in linked_logs)
 				),
 				title=_("Unlinked logs"),
 				indicator="blue",
@@ -302,27 +284,16 @@ class Attendance(Document):
 		self.publish_update()
 
 	def publish_update(self):
-		employee_user = frappe.db.get_value(
-			"Employee", self.employee, "user_id", cache=True
-		)
-		hrms.refetch_resource("hrms:attendance_calendar_events", employee_user)
-
-	def on_update(self):
-		self.publish_update()
-
-	def after_delete(self):
-		self.publish_update()
-
-	def publish_update(self):
 		employee_user = frappe.db.get_value("Employee", self.employee, "user_id", cache=True)
 		hrms.refetch_resource("hrms:attendance_calendar_events", employee_user)
 
 
 @frappe.whitelist()
-def get_events(start, end, filters=None):
+def get_events(start: date | str, end: date | str, filters: str | list | None = None) -> list[dict]:
 	employee = frappe.db.get_value("Employee", {"user_id": frappe.session.user})
 	if not employee:
 		return []
+
 	if isinstance(filters, str):
 		import json
 
@@ -340,7 +311,7 @@ def add_attendance(filters):
 		"Attendance",
 		fields=[
 			"name",
-			"'Attendance' as doctype",
+			ValueWrapper("Attendance").as_("doctype"),
 			"attendance_date",
 			"employee_name",
 			"status",
@@ -349,7 +320,7 @@ def add_attendance(filters):
 		filters=filters,
 	)
 	for record in attendance:
-		record["title"] = f"{record.employee_name} : {record.status}"
+		record["title"] = f"{record['employee_name']} : {record['status']}"
 	return attendance
 
 
@@ -408,7 +379,7 @@ def mark_attendance(
 
 
 @frappe.whitelist()
-def mark_bulk_attendance(data):
+def mark_bulk_attendance(data: str | dict):
 	import json
 
 	if isinstance(data, str):
@@ -417,21 +388,54 @@ def mark_bulk_attendance(data):
 	if not data.unmarked_days:
 		frappe.throw(_("Please select a date."))
 		return
+	if len(data.unmarked_days) > 10 or frappe.flags.test_bg_job:
+		job_id = f"process_bulk_attendance_for_employee_{data.employee}"
+		job = frappe.enqueue(
+			process_bulk_attendance_in_batches, data=data, job_id=job_id, timeout=600, deduplicate=True
+		)
+		if job:
+			message = _(
+				"Bulk attendance marking is queued with a background job. It may take a while. You can monitor the job status {0}"
+			).format(get_link_to_form("RQ Job", job.id, label="here"))
+		else:
+			message = _(
+				"Bulk attendance marking is already in progress for employee {0}. You can monitor the job status {1}"
+			).format(frappe.bold(data.employee), get_link_to_form("RQ Job", get_job(job_id).id, label="here"))
+		frappe.msgprint(message, allow_dangerous_html=True)
+	else:
+		process_bulk_attendance_in_batches(data)
+		frappe.msgprint(_("Attendance marked successfully."), alert=True)
 
-	for date in data.unmarked_days:
-		doc_dict = {
-			"doctype": "Attendance",
-			"employee": data.employee,
-			"attendance_date": get_datetime(date),
-			"status": data.status,
-			"half_day_status": "Absent" if data.status == "Half Day" else None,
-		}
-		attendance = frappe.get_doc(doc_dict).insert()
-		attendance.submit()
+
+def process_bulk_attendance_in_batches(data, chunk_size=20):
+	savepoint = "mark_bulk_attendance"
+	for days in create_batch(data.unmarked_days, chunk_size):
+		for attendance_date in days:
+			try:
+				frappe.db.savepoint(savepoint)
+				doc_dict = {
+					"doctype": "Attendance",
+					"employee": data.employee,
+					"attendance_date": getdate(attendance_date),
+					"status": data.status,
+					"half_day_status": "Absent" if data.status == "Half Day" else None,
+					"shift": data.shift,
+				}
+				attendance = frappe.get_doc(doc_dict).insert()
+				attendance.submit()
+			except (DuplicateAttendanceError, OverlappingShiftAttendanceError, Exception):
+				if not frappe.flags.in_test:
+					frappe.db.rollback(save_point=savepoint)
+				continue
+		if not frappe.flags.in_test:
+			frappe.db.commit()  # nosemgrep
 
 
 @frappe.whitelist()
-def get_unmarked_days(employee, from_date, to_date, exclude_holidays=0):
+def get_unmarked_days(
+	employee: str, from_date: str | date, to_date: str | date, exclude_holidays: str | int = 0
+) -> list:
+	frappe.has_permission("Employee", "read", employee, throw=True)
 	joining_date, relieving_date = frappe.get_cached_value(
 		"Employee", employee, ["date_of_joining", "relieving_date"]
 	)
@@ -453,7 +457,9 @@ def get_unmarked_days(employee, from_date, to_date, exclude_holidays=0):
 	marked_days = [getdate(record.attendance_date) for record in records]
 
 	if cint(exclude_holidays):
-		holiday_dates = get_holiday_dates_for_employee(employee, from_date, to_date)
+		holiday_dates = get_holiday_dates_between_range(
+			employee, from_date, to_date, raise_exception_for_holiday_list=False
+		)
 		holidays = [getdate(record) for record in holiday_dates]
 		marked_days.extend(holidays)
 
@@ -466,3 +472,42 @@ def get_unmarked_days(employee, from_date, to_date, exclude_holidays=0):
 		from_date = add_days(from_date, 1)
 
 	return unmarked_days
+
+
+@frappe.whitelist()
+def get_employee_shift(employee: str, for_date: str | date | None = None) -> str | None:
+	if not employee:
+		return None
+
+	if employee and not frappe.has_permission("Employee", "read", employee):
+		return None
+
+	if not for_date:
+		for_date = nowdate()
+
+	for_date = getdate(for_date)
+
+	if not frappe.has_permission("Shift Assignment", "read"):
+		return None
+
+	shifts = frappe.get_all(
+		"Shift Assignment",
+		filters={
+			"employee": employee,
+			"docstatus": 1,
+			"status": "Active",
+			"start_date": ("<=", for_date),
+		},
+		fields=["shift_type", "start_date"],
+		order_by="start_date desc",
+		limit=1,
+	)
+
+	if shifts:
+		return shifts[0].shift_type
+
+	default_shift = frappe.db.get_value("Employee", employee, "default_shift")
+	if default_shift:
+		return default_shift
+
+	return None

--- a/hrms/hr/doctype/employee_advance/employee_advance.js
+++ b/hrms/hr/doctype/employee_advance/employee_advance.js
@@ -15,27 +15,13 @@ frappe.ui.form.on("Employee Advance", {
 			if (!frm.doc.employee) {
 				frappe.msgprint(__("Please select employee first"));
 			}
-			let company_currency = erpnext.get_currency(frm.doc.company);
-			let currencies = [company_currency];
-			if (frm.doc.currency && frm.doc.currency != company_currency) {
-				currencies.push(frm.doc.currency);
-			}
-
 			return {
 				filters: {
 					root_type: "Asset",
 					is_group: 0,
 					company: frm.doc.company,
-					account_currency: ["in", currencies],
+					account_currency: frm.doc.currency,
 					account_type: "Receivable",
-				},
-			};
-		});
-
-		frm.set_query("salary_component", function () {
-			return {
-				filters: {
-					type: "Deduction",
 				},
 			};
 		});
@@ -45,7 +31,8 @@ frappe.ui.form.on("Employee Advance", {
 		if (
 			frm.doc.docstatus === 1 &&
 			flt(frm.doc.paid_amount) < flt(frm.doc.advance_amount) &&
-			frappe.model.can_create("Payment Entry")
+			frappe.model.can_create("Payment Entry") &&
+			!(frm.doc.repay_unclaimed_amount_from_salary == 1 && frm.doc.paid_amount)
 		) {
 			frm.add_custom_button(
 				__("Payment"),
@@ -54,7 +41,9 @@ frappe.ui.form.on("Employee Advance", {
 				},
 				__("Create"),
 			);
-		} else if (
+		}
+
+		if (
 			frm.doc.docstatus === 1 &&
 			flt(frm.doc.claimed_amount) < flt(frm.doc.paid_amount) - flt(frm.doc.return_amount) &&
 			frappe.model.can_create("Expense Claim")
@@ -67,6 +56,7 @@ frappe.ui.form.on("Employee Advance", {
 				__("Create"),
 			);
 		}
+		frm.trigger("update_fields_label");
 
 		if (
 			frm.doc.docstatus === 1 &&
@@ -96,6 +86,14 @@ frappe.ui.form.on("Employee Advance", {
 				);
 			}
 		}
+		if (frm.doc.status === "Returned") {
+			frm.dashboard.clear_headline();
+			return;
+		}
+
+		if (frm.doc.docstatus === 1) {
+			frm.trigger("render_employee_advance_return_banner");
+		}
 	},
 
 	make_deduction_via_additional_salary: function (frm) {
@@ -112,12 +110,8 @@ frappe.ui.form.on("Employee Advance", {
 	},
 
 	make_payment_entry: function (frm) {
-		let method = "hrms.overrides.employee_payment_entry.get_payment_entry_for_employee";
-		if (frm.doc.__onload && frm.doc.__onload.make_payment_via_journal_entry) {
-			method = "hrms.hr.doctype.employee_advance.employee_advance.make_bank_entry";
-		}
 		return frappe.call({
-			method: method,
+			method: "hrms.overrides.employee_payment_entry.get_payment_entry_for_employee",
 			args: {
 				dt: frm.doc.doctype,
 				dn: frm.doc.name,
@@ -133,13 +127,7 @@ frappe.ui.form.on("Employee Advance", {
 		return frappe.call({
 			method: "hrms.hr.doctype.expense_claim.expense_claim.get_expense_claim",
 			args: {
-				employee_name: frm.doc.employee,
-				company: frm.doc.company,
-				employee_advance_name: frm.doc.name,
-				posting_date: frm.doc.posting_date,
-				paid_amount: frm.doc.paid_amount,
-				claimed_amount: frm.doc.claimed_amount,
-				return_amount: frm.doc.return_amount,
+				employee_advance: frm.doc.name,
 			},
 			callback: function (r) {
 				const doclist = frappe.model.sync(r.message);
@@ -159,7 +147,6 @@ frappe.ui.form.on("Employee Advance", {
 				advance_account: frm.doc.advance_account,
 				mode_of_payment: frm.doc.mode_of_payment,
 				currency: frm.doc.currency,
-				exchange_rate: frm.doc.exchange_rate,
 			},
 			callback: function (r) {
 				const doclist = frappe.model.sync(r.message);
@@ -169,56 +156,59 @@ frappe.ui.form.on("Employee Advance", {
 	},
 
 	employee: function (frm) {
-		if (frm.doc.employee) frm.trigger("get_employee_currency");
-	},
-
-	get_employee_currency: function (frm) {
-		frappe.db.get_value(
-			"Salary Structure Assignment",
-			{ employee: frm.doc.employee, docstatus: 1 },
-			"currency",
-			(r) => {
-				if (r.currency) frm.set_value("currency", r.currency);
-				else frm.set_value("currency", erpnext.get_currency(frm.doc.company));
-				frm.refresh_fields();
-			},
-		);
-	},
-
-	currency: function (frm) {
-		if (frm.doc.currency) {
-			var from_currency = frm.doc.currency;
-			var company_currency;
-			if (!frm.doc.company) {
-				company_currency = erpnext.get_currency(frappe.defaults.get_default("Company"));
-			} else {
-				company_currency = erpnext.get_currency(frm.doc.company);
-			}
-			if (from_currency != company_currency) {
-				frm.events.set_exchange_rate(frm, from_currency, company_currency);
-			} else {
-				frm.set_value("exchange_rate", 1.0);
-				frm.set_df_property("exchange_rate", "hidden", 1);
-				frm.set_df_property("exchange_rate", "description", "");
-			}
-			frm.refresh_fields();
+		if (frm.doc.employee) {
+			frm.trigger("update_fields_label");
 		}
 	},
 
-	set_exchange_rate: function (frm, from_currency, company_currency) {
+	update_fields_label: function (frm) {
+		var company_currency = erpnext.get_currency(frm.doc.company);
+		if (frm.doc.currency != company_currency) {
+			frm.set_currency_labels(["paid_amount"], frm.doc.currency);
+			frm.set_currency_labels(["base_paid_amount"], company_currency);
+		}
+		frm.toggle_display("base_paid_amount", frm.doc.currency != company_currency);
+		frm.refresh_fields();
+	},
+
+	render_employee_advance_return_banner(frm) {
 		frappe.call({
-			method: "erpnext.setup.utils.get_exchange_rate",
+			method: "hrms.hr.doctype.employee_advance.employee_advance.get_employee_advance_return",
 			args: {
-				from_currency: from_currency,
-				to_currency: company_currency,
+				employee_advance: frm.doc.name,
 			},
-			callback: function (r) {
-				frm.set_value("exchange_rate", flt(r.message));
-				frm.set_df_property("exchange_rate", "hidden", 0);
-				frm.set_df_property(
-					"exchange_rate",
-					"description",
-					"1 " + frm.doc.currency + " = [?] " + company_currency,
+			error() {
+				frm.dashboard.clear_headline();
+			},
+			callback(r) {
+				const advance_return_data = r.message || {};
+
+				if (!advance_return_data.has_return_scheduled) {
+					frm.dashboard.clear_headline();
+					return;
+				}
+
+				const filters = {
+					ref_doctype: "Employee Advance",
+					ref_docname: frm.doc.name,
+					docstatus: 1,
+				};
+
+				const url =
+					"/app/list/additional-salary?" + new URLSearchParams(filters).toString();
+
+				frm.dashboard.set_headline(
+					__(
+						"Employee Advance return is scheduled via Additional Salary: {0} | <a href='{1}'> {2} </a>",
+						[
+							format_currency(
+								advance_return_data.total_return_scheduled,
+								frm.doc.currency,
+							),
+							url,
+							__("View Additional Salary entries").bold(),
+						],
+					),
 				);
 			},
 		});

--- a/hrms/hr/doctype/employee_advance/employee_advance.json
+++ b/hrms/hr/doctype/employee_advance/employee_advance.json
@@ -17,12 +17,12 @@
   "currency_section",
   "currency",
   "column_break_crso",
-  "exchange_rate",
   "section_break_8",
   "purpose",
   "column_break_11",
   "advance_amount",
   "paid_amount",
+  "base_paid_amount",
   "pending_amount",
   "claimed_amount",
   "return_amount",
@@ -104,15 +104,6 @@
    "reqd": 1
   },
   {
-   "description": "Amount that has been paid against this advance",
-   "fieldname": "paid_amount",
-   "fieldtype": "Currency",
-   "label": "Paid Amount",
-   "no_copy": 1,
-   "options": "currency",
-   "read_only": 1
-  },
-  {
    "description": "Amount claimed via Expense Claim",
    "fieldname": "claimed_amount",
    "fieldtype": "Currency",
@@ -131,7 +122,7 @@
    "fieldtype": "Select",
    "label": "Status",
    "no_copy": 1,
-   "options": "Draft\nPaid\nUnpaid\nClaimed\nReturned\nPartly Claimed and Returned\nCancelled",
+   "options": "Draft\nPaid\nPartially Paid\nUnpaid\nClaimed\nReturned\nPartly Claimed and Returned\nCancelled",
    "read_only": 1
   },
   {
@@ -157,7 +148,8 @@
    "fieldtype": "Column Break"
   },
   {
-   "fetch_from": "company.default_employee_advance_account",
+   "fetch_from": "employee.employee_advance_account",
+   "fetch_if_empty": 1,
    "fieldname": "advance_account",
    "fieldtype": "Link",
    "ignore_user_permissions": 1,
@@ -172,7 +164,7 @@
   },
   {
    "allow_on_submit": 1,
-   "description": "Amount returned by the employee after the advance is paid",
+   "description": "Amount scheduled for deduction via salary",
    "fieldname": "return_amount",
    "fieldtype": "Currency",
    "label": "Returned Amount",
@@ -198,19 +190,12 @@
   },
   {
    "depends_on": "eval:(doc.docstatus==1 || doc.employee)",
+   "fetch_from": "employee.salary_currency",
+   "fetch_if_empty": 1,
    "fieldname": "currency",
    "fieldtype": "Link",
    "label": "Currency",
    "options": "Currency",
-   "reqd": 1
-  },
-  {
-   "depends_on": "currency",
-   "fieldname": "exchange_rate",
-   "fieldtype": "Float",
-   "label": "Exchange Rate",
-   "precision": "9",
-   "print_hide": 1,
    "reqd": 1
   },
   {
@@ -236,12 +221,30 @@
   {
    "fieldname": "column_break_crso",
    "fieldtype": "Column Break"
+  },
+  {
+   "description": "Amount that has been paid against this advance",
+   "fieldname": "base_paid_amount",
+   "fieldtype": "Currency",
+   "label": "Paid Amount (Company Currency)",
+   "no_copy": 1,
+   "options": "Company:company:default_currency",
+   "read_only": 1
+  },
+  {
+   "description": "Amount that has been paid against this advance",
+   "fieldname": "paid_amount",
+   "fieldtype": "Currency",
+   "label": "Paid Amount",
+   "no_copy": 1,
+   "options": "currency",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-06-16 12:09:38.685483",
+ "modified": "2025-11-10 23:18:24.203679",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Employee Advance",
@@ -275,6 +278,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "employee,employee_name",
  "sort_field": "creation",
  "sort_order": "DESC",
@@ -287,6 +291,10 @@
    "color": "Green",
    "title": "Paid"
   },
+    {
+     "color": "Blue",
+     "title": "Partially Paid"
+    },
   {
    "color": "Orange",
    "title": "Unpaid"

--- a/hrms/hr/doctype/employee_advance/employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/employee_advance.py
@@ -6,7 +6,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.query_builder.functions import Abs, Sum
-from frappe.utils import flt, nowdate
+from frappe.utils import flt, get_link_to_form, nowdate
 
 import erpnext
 from erpnext.accounts.doctype.journal_entry.journal_entry import get_default_bank_cash_account
@@ -20,14 +20,48 @@ class EmployeeAdvanceOverPayment(frappe.ValidationError):
 
 
 class EmployeeAdvance(Document):
-	def onload(self):
-		self.get("__onload").make_payment_via_journal_entry = frappe.db.get_single_value(
-			"Accounts Settings", "make_payment_via_journal_entry"
-		)
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		advance_account: DF.Link | None
+		advance_amount: DF.Currency
+		amended_from: DF.Link | None
+		base_paid_amount: DF.Currency
+		claimed_amount: DF.Currency
+		company: DF.Link
+		currency: DF.Link
+		department: DF.Link | None
+		employee: DF.Link
+		employee_name: DF.ReadOnly | None
+		mode_of_payment: DF.Link | None
+		naming_series: DF.Literal["HR-EAD-.YYYY.-"]
+		paid_amount: DF.Currency
+		pending_amount: DF.Currency
+		posting_date: DF.Date
+		purpose: DF.SmallText
+		repay_unclaimed_amount_from_salary: DF.Check
+		return_amount: DF.Currency
+		status: DF.Literal[
+			"Draft",
+			"Paid",
+			"Partially Paid",
+			"Unpaid",
+			"Claimed",
+			"Returned",
+			"Partly Claimed and Returned",
+			"Cancelled",
+		]
+	# end: auto-generated types
 
 	def validate(self):
 		validate_active_employee(self.employee)
-		self.validate_exchange_rate()
+		self.validate_advance_account_currency()
+		self.validate_advance_account_type()
 		self.set_status()
 		self.set_pending_amount()
 
@@ -36,15 +70,32 @@ class EmployeeAdvance(Document):
 			default_advance_account = frappe.db.get_value(
 				"Company", self.company, "default_employee_advance_account"
 			)
-			if default_advance_account:
+			same_currency = self.currency == erpnext.get_company_currency(self.company)
+
+			if default_advance_account and same_currency:
 				self.advance_account = default_advance_account
-			else:
+				return
+
+			if not same_currency:
 				frappe.throw(
-					_(
-						'Advance Account is mandatory. Please set the <a href="/app/company/{0}#default_employee_advance_account" target="_blank">Default Employee Advance Account</a> in the Company record {0} and submit this document.'
-					).format(self.company),
-					title=_("Missing Advance Account"),
+					_("Please set the Advance Account {0} or in {1}").format(
+						get_link_to_form("Employee Advance", self.name + "#advance_account", _("here")),
+						get_link_to_form("Employee", self.employee + "#salary_information", self.employee),
+					),
+					title=_("Advance Account Required"),
 				)
+
+			frappe.throw(
+				_(
+					"Advance Account is mandatory. Please set the {0} in the Company {1} and submit this document."
+				).format(
+					get_link_to_form(
+						"Company", self.company + "#hr_and_payroll_tab", "Default Employee Advance Account"
+					),
+					frappe.bold(self.company),
+				),
+				title=_("Missing Advance Account"),
+			)
 
 	def on_cancel(self):
 		self.ignore_linked_doctypes = ("GL Entry", "Payment Ledger Entry", "Advance Payment Ledger Entry")
@@ -61,9 +112,27 @@ class EmployeeAdvance(Document):
 		employee_user = frappe.db.get_value("Employee", self.employee, "user_id", cache=True)
 		hrms.refetch_resource("hrms:employee_advance_balance", employee_user)
 
-	def validate_exchange_rate(self):
-		if not self.exchange_rate:
-			frappe.throw(_("Exchange Rate cannot be zero."))
+	def validate_advance_account_type(self):
+		if not self.advance_account:
+			return
+
+		account_type = frappe.db.get_value("Account", self.advance_account, "account_type")
+		if not account_type or (account_type != "Receivable"):
+			frappe.throw(
+				_("Employee advance account {0} should be of type {1}.").format(
+					get_link_to_form("Account", self.advance_account), frappe.bold(_("Receivable"))
+				)
+			)
+
+	def validate_advance_account_currency(self):
+		if self.currency and self.advance_account:
+			account_currency = frappe.db.get_value("Account", self.advance_account, "account_currency")
+			if self.currency != account_currency:
+				frappe.throw(
+					_(
+						"Advance Account {} currency should be same as Salary Currency of Employee {}. Please select same currency Advance Account"
+					).format(frappe.bold(self.advance_account), frappe.bold(self.employee))
+				)
 
 	def set_status(self, update=False):
 		precision = self.precision("paid_amount")
@@ -91,6 +160,8 @@ class EmployeeAdvance(Document):
 				self.paid_amount, precision
 			):
 				status = "Paid"
+			elif flt(self.paid_amount) > 0:
+				status = "Partially Paid"
 			else:
 				status = "Unpaid"
 		elif self.docstatus == 2:
@@ -103,13 +174,13 @@ class EmployeeAdvance(Document):
 		else:
 			self.status = status
 
+	def on_discard(self):
+		self.db_set("status", "Cancelled")
+
 	def set_total_advance_paid(self):
 		aple = frappe.qb.DocType("Advance Payment Ledger Entry")
-		account_type, account_curreny = frappe.get_value(
-			"Account", self.advance_account, ["account_type", "account_currency"]
-		)
 
-		company_currency = frappe.get_value("Company", self.company, "default_currency")
+		account_type = frappe.get_value("Account", self.advance_account, "account_type")
 
 		if account_type == "Receivable":
 			paid_amount_condition = aple.amount > 0
@@ -119,21 +190,27 @@ class EmployeeAdvance(Document):
 			returned_amount_condition = aple.amount > 0
 		else:
 			frappe.throw(
-				_("Employee advance account {0} should be of type {1}").format(
-					frappe.bold(self.advance_account), frappe.bold("Receivable")
+				_("Employee advance account {0} should be of type {1}.").format(
+					get_link_to_form("Account", self.advance_account),
+					frappe.bold(_("Receivable")),
 				)
 			)
-		paid_amount = (
+
+		aple_paid_amount = (
 			frappe.qb.from_(aple)
 			.select(Abs(Sum(aple.amount)).as_("paid_amount"))
+			.select(Abs(Sum(aple.base_amount)).as_("base_paid_amount"))
 			.where(
 				(aple.company == self.company)
 				& (aple.delinked == 0)
 				& (aple.against_voucher_type == self.doctype)
 				& (aple.against_voucher_no == self.name)
-				& (paid_amount_condition < 0)
+				& (paid_amount_condition)
+				& (aple.event == "Submit")
 			)
-		).run(as_dict=True)[0].paid_amount or 0
+		).run(as_dict=True)[0] or {}
+		paid_amount = aple_paid_amount.get("paid_amount") or 0
+
 		return_amount = (
 			frappe.qb.from_(aple)
 			.select(Abs(Sum(aple.amount)).as_("return_amount"))
@@ -142,13 +219,10 @@ class EmployeeAdvance(Document):
 				& (aple.delinked == 0)
 				& (aple.against_voucher_type == self.doctype)
 				& (aple.against_voucher_no == self.name)
+				& (aple.voucher_type != "Expense Claim")
 				& (returned_amount_condition)
 			)
 		).run(as_dict=True)[0].return_amount or 0
-
-		if company_currency != self.currency and account_curreny == company_currency:
-			paid_amount = flt(paid_amount) / flt(self.exchange_rate)
-			return_amount = flt(return_amount) / flt(self.exchange_rate)
 
 		precision = self.precision("paid_amount")
 		paid_amount = flt(paid_amount, precision)
@@ -161,47 +235,54 @@ class EmployeeAdvance(Document):
 		precision = self.precision("return_amount")
 		return_amount = flt(return_amount, precision)
 
-		if return_amount > 0 and return_amount > flt(self.paid_amount - self.claimed_amount, precision):
+		if return_amount > 0 and return_amount > flt(paid_amount - self.claimed_amount, precision):
 			frappe.throw(_("Return amount cannot be greater than unclaimed amount"))
 
 		self.db_set("paid_amount", paid_amount)
 		self.db_set("return_amount", return_amount)
 		self.set_status(update=True)
+		self.set_pending_amount(update=True)
+
+		base_paid_amount = aple_paid_amount.get("base_paid_amount") or 0
+		self.db_set("base_paid_amount", base_paid_amount)
 
 	def update_claimed_amount(self):
-		claimed_amount = (
-			frappe.db.sql(
-				"""
-			SELECT sum(ifnull(allocated_amount, 0))
-			FROM `tabExpense Claim Advance` eca, `tabExpense Claim` ec
-			WHERE
-				eca.employee_advance = %s
-				AND ec.approval_status="Approved"
-				AND ec.name = eca.parent
-				AND ec.docstatus=1
-				AND eca.allocated_amount > 0
-		""",
-				self.name,
-			)[0][0]
-			or 0
-		)
+		ec = frappe.qb.DocType("Expense Claim")
+		eca = frappe.qb.DocType("Expense Claim Advance")
 
+		claimed_amount = (
+			frappe.qb.from_(ec)
+			.join(eca)
+			.on(ec.name == eca.parent)
+			.select(Sum(eca.allocated_amount))
+			.where(
+				(eca.employee_advance == self.name)
+				& (eca.allocated_amount > 0)
+				& (ec.approval_status == "Approved")
+				& (ec.docstatus == 1)
+			)
+		).run()[0][0] or 0
 		frappe.db.set_value("Employee Advance", self.name, "claimed_amount", flt(claimed_amount))
 		self.reload()
 		self.set_status(update=True)
 
-	def set_pending_amount(self):
+	def set_pending_amount(self, update=False):
 		Advance = frappe.qb.DocType("Employee Advance")
-		self.pending_amount = (
+		pending_amount = (
 			frappe.qb.from_(Advance)
 			.select(Sum(Advance.advance_amount - Advance.paid_amount))
 			.where(
 				(Advance.employee == self.employee)
 				& (Advance.docstatus == 1)
 				& (Advance.posting_date <= self.posting_date)
-				& (Advance.status == "Unpaid")
+				& (Advance.status.isin(["Unpaid", "Partially Paid"]))
 			)
 		).run()[0][0] or 0.0
+
+		if update:
+			self.db_set("pending_amount", pending_amount)
+		else:
+			self.pending_amount = pending_amount
 
 	def check_linked_payment_entry(self):
 		from erpnext.accounts.utils import (
@@ -215,84 +296,7 @@ class EmployeeAdvance(Document):
 
 
 @frappe.whitelist()
-def make_bank_entry(dt, dn):
-	doc = frappe.get_doc(dt, dn)
-	payment_account = get_default_bank_cash_account(
-		doc.company, account_type="Cash", mode_of_payment=doc.mode_of_payment
-	)
-	if not payment_account:
-		frappe.throw(_("Please set a Default Cash Account in Company defaults"))
-
-	advance_account_currency = frappe.db.get_value("Account", doc.advance_account, "account_currency")
-
-	advance_amount, advance_exchange_rate = get_advance_amount_advance_exchange_rate(
-		advance_account_currency, doc
-	)
-
-	paying_amount, paying_exchange_rate = get_paying_amount_paying_exchange_rate(payment_account, doc)
-
-	je = frappe.new_doc("Journal Entry")
-	je.posting_date = nowdate()
-	je.voucher_type = "Bank Entry"
-	je.company = doc.company
-	je.remark = "Payment against Employee Advance: " + dn + "\n" + doc.purpose
-	je.multi_currency = 1 if advance_account_currency != payment_account.account_currency else 0
-
-	je.append(
-		"accounts",
-		{
-			"account": doc.advance_account,
-			"account_currency": advance_account_currency,
-			"exchange_rate": flt(advance_exchange_rate),
-			"debit_in_account_currency": flt(advance_amount),
-			"reference_type": "Employee Advance",
-			"reference_name": doc.name,
-			"party_type": "Employee",
-			"cost_center": erpnext.get_default_cost_center(doc.company),
-			"party": doc.employee,
-			"is_advance": "Yes",
-		},
-	)
-
-	je.append(
-		"accounts",
-		{
-			"account": payment_account.account,
-			"cost_center": erpnext.get_default_cost_center(doc.company),
-			"credit_in_account_currency": flt(paying_amount),
-			"account_currency": payment_account.account_currency,
-			"account_type": payment_account.account_type,
-			"exchange_rate": flt(paying_exchange_rate),
-		},
-	)
-	je.flags.ignore_party_account_validation = True
-	return je.as_dict()
-
-
-def get_advance_amount_advance_exchange_rate(advance_account_currency, doc):
-	if advance_account_currency != doc.currency:
-		advance_amount = flt(doc.advance_amount) * flt(doc.exchange_rate)
-		advance_exchange_rate = 1
-	else:
-		advance_amount = doc.advance_amount
-		advance_exchange_rate = doc.exchange_rate
-
-	return advance_amount, advance_exchange_rate
-
-
-def get_paying_amount_paying_exchange_rate(payment_account, doc):
-	if payment_account.account_currency != doc.currency:
-		paying_amount = flt(doc.advance_amount) * flt(doc.exchange_rate)
-		paying_exchange_rate = 1
-	else:
-		paying_amount = doc.advance_amount
-		paying_exchange_rate = doc.exchange_rate
-
-	return paying_amount, paying_exchange_rate
-
-
-@frappe.whitelist()
-def create_return_through_additional_salary(doc):
+def create_return_through_additional_salary(doc: str | dict | Document) -> Document:
 	import json
 
 	if isinstance(doc, str):
@@ -312,20 +316,15 @@ def create_return_through_additional_salary(doc):
 
 @frappe.whitelist()
 def make_return_entry(
-	employee,
-	company,
-	employee_advance_name,
-	return_amount,
-	advance_account,
-	currency,
-	exchange_rate,
-	mode_of_payment=None,
-):
-	bank_cash_account = get_default_bank_cash_account(
-		company, account_type="Cash", mode_of_payment=mode_of_payment
-	)
-	if not bank_cash_account:
-		frappe.throw(_("Please set a Default Cash Account in Company defaults"))
+	employee: str,
+	company: str,
+	employee_advance_name: str,
+	return_amount: str | float,
+	advance_account: str,
+	currency: str,
+	mode_of_payment: str | None = None,
+) -> dict:
+	bank_cash_account = get_same_currency_bank_cash_account(company, currency, mode_of_payment)
 
 	advance_account_currency = frappe.db.get_value("Account", advance_account, "account_currency")
 
@@ -334,13 +333,9 @@ def make_return_entry(
 	je.voucher_type = get_voucher_type(mode_of_payment)
 	je.company = company
 	je.remark = "Return against Employee Advance: " + employee_advance_name
-	je.multi_currency = 1 if advance_account_currency != bank_cash_account.account_currency else 0
+	je.multi_currency = 1 if advance_account_currency != erpnext.get_company_currency(company) else 0
 
-	advance_account_amount = (
-		flt(return_amount)
-		if advance_account_currency == currency
-		else flt(return_amount) * flt(exchange_rate)
-	)
+	advance_account_amount = flt(return_amount)
 
 	je.append(
 		"accounts",
@@ -348,7 +343,6 @@ def make_return_entry(
 			"account": advance_account,
 			"credit_in_account_currency": advance_account_amount,
 			"account_currency": advance_account_currency,
-			"exchange_rate": flt(exchange_rate) if advance_account_currency == currency else 1,
 			"reference_type": "Employee Advance",
 			"reference_name": employee_advance_name,
 			"party_type": "Employee",
@@ -358,25 +352,54 @@ def make_return_entry(
 		},
 	)
 
-	bank_amount = (
-		flt(return_amount)
-		if bank_cash_account.account_currency == currency
-		else flt(return_amount) * flt(exchange_rate)
-	)
-
+	bank_amount = flt(return_amount)
 	je.append(
 		"accounts",
 		{
-			"account": bank_cash_account.account,
+			"account": bank_cash_account.account or bank_cash_account.name,
 			"debit_in_account_currency": bank_amount,
 			"account_currency": bank_cash_account.account_currency,
 			"account_type": bank_cash_account.account_type,
-			"exchange_rate": flt(exchange_rate) if bank_cash_account.account_currency == currency else 1,
 			"cost_center": erpnext.get_default_cost_center(company),
 		},
 	)
 
 	return je.as_dict()
+
+
+def get_same_currency_bank_cash_account(company, currency, mode_of_payment=None):
+	company_currency = erpnext.get_company_currency(company)
+	if currency == company_currency:
+		return get_default_bank_cash_account(company, account_type="Cash", mode_of_payment=mode_of_payment)
+
+	account = None
+	if mode_of_payment:
+		from erpnext.accounts.doctype.sales_invoice.sales_invoice import get_bank_cash_account
+
+		account = get_bank_cash_account(mode_of_payment, company).get("account")
+
+	if not account:
+		accounts = frappe.get_all(
+			"Account",
+			filters={
+				"company": company,
+				"account_currency": currency,
+				"account_type": ["in", ["Cash", "Bank"]],
+				"is_group": 0,
+			},
+			limit=1,
+		)
+		if not accounts:
+			frappe.throw(
+				_("No Bank/Cash Account found for currency {0}. Please create one under company {1}.").format(
+					frappe.bold(currency), company
+				),
+				title=_("Account Not Found"),
+			)
+		account = accounts[0].name
+	return frappe.get_cached_value(
+		"Account", account, ["name", "account_currency", "account_type"], as_dict=True
+	)
 
 
 def get_voucher_type(mode_of_payment=None):
@@ -388,3 +411,28 @@ def get_voucher_type(mode_of_payment=None):
 			voucher_type = "Bank Entry"
 
 	return voucher_type
+
+
+@frappe.whitelist()
+def get_employee_advance_return(employee_advance: str):
+	frappe.has_permission("Employee Advance", ptype="read", doc=employee_advance, throw=True)
+
+	AdditionalSalary = frappe.qb.DocType("Additional Salary")
+	return_entries = (
+		frappe.qb.from_(AdditionalSalary)
+		.select(Sum(AdditionalSalary.amount).as_("total_return_scheduled"))
+		.where(
+			(AdditionalSalary.ref_doctype == "Employee Advance")
+			& (AdditionalSalary.ref_docname == employee_advance)
+			& (AdditionalSalary.docstatus == 1)
+		)
+	).run(as_dict=True)
+
+	total_return_scheduled = flt(return_entries[0].total_return_scheduled)
+	already_returned = flt(frappe.db.get_value("Employee Advance", employee_advance, "return_amount"))
+	pending_scheduled = max(0, total_return_scheduled - already_returned)
+
+	return {
+		"total_return_scheduled": pending_scheduled,
+		"has_return_scheduled": bool(pending_scheduled),
+	}

--- a/hrms/hr/doctype/employee_advance/test_employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/test_employee_advance.py
@@ -2,7 +2,7 @@
 # See license.txt
 
 import frappe
-from frappe.tests.utils import FrappeTestCase, change_settings
+from frappe import _dict
 from frappe.utils import flt, nowdate
 
 import erpnext
@@ -12,35 +12,34 @@ from erpnext.setup.doctype.employee.test_employee import make_employee
 from hrms.hr.doctype.employee_advance.employee_advance import (
 	EmployeeAdvanceOverPayment,
 	create_return_through_additional_salary,
-	make_bank_entry,
+	get_same_currency_bank_cash_account,
 	make_return_entry,
 )
-from hrms.hr.doctype.expense_claim.expense_claim import get_advances, get_allocation_amount
+from hrms.hr.doctype.expense_claim.expense_claim import get_advances, get_expense_claim
 from hrms.hr.doctype.expense_claim.test_expense_claim import (
 	get_payable_account,
 	make_expense_claim,
 )
+from hrms.payroll.doctype.payroll_entry.payroll_entry import get_start_end_dates
+from hrms.payroll.doctype.payroll_entry.test_payroll_entry import make_payroll_entry, setup_salary_structure
 from hrms.payroll.doctype.salary_component.test_salary_component import create_salary_component
 from hrms.payroll.doctype.salary_structure.test_salary_structure import make_salary_structure
+from hrms.tests.utils import HRMSTestSuite
 
 
-class TestEmployeeAdvance(IntegrationTestCase):
+class TestEmployeeAdvance(HRMSTestSuite):
 	def setUp(self):
 		frappe.db.delete("Employee Advance")
 		self.update_company_in_fiscal_year()
 		frappe.db.set_value("Account", "Employee Advances - _TC", "account_type", "Receivable")
 		frappe.db.set_value("Account", "_Test Employee Advance - _TC", "account_type", "Receivable")
-
-	def tearDown(self):
-		frappe.set_value(
-			"Company", "_Test Company", "default_employee_advance_account", "Employee Advances - _TC"
-		)
+		frappe.db.set_value("Account", "Payroll Payable - _TC", "account_type", "Payable")
 
 	def test_paid_amount_and_status(self):
 		employee_name = make_employee("_T@employee.advance", "_Test Company")
 		advance = make_employee_advance(employee_name)
 
-		journal_entry = make_journal_entry_for_advance(advance)
+		journal_entry = manual_journal_entry_for_advance(advance)
 		journal_entry.submit()
 
 		advance.reload()
@@ -49,22 +48,19 @@ class TestEmployeeAdvance(IntegrationTestCase):
 		self.assertEqual(advance.status, "Paid")
 
 		# try making over payment
-		journal_entry1 = make_journal_entry_for_advance(advance)
+		journal_entry1 = manual_journal_entry_for_advance(advance)
 		self.assertRaises(EmployeeAdvanceOverPayment, journal_entry1.submit)
 
 	def test_paid_amount_on_pe_cancellation(self):
 		employee_name = make_employee("_T@employee.advance", "_Test Company")
 		advance = make_employee_advance(employee_name)
-
-		journal_entry = make_journal_entry_for_advance(advance)
-		journal_entry.submit()
-
+		payment_entry = make_payment_entry(advance)
 		advance.reload()
 
 		self.assertEqual(advance.paid_amount, 1000)
 		self.assertEqual(advance.status, "Paid")
 
-		journal_entry.cancel()
+		payment_entry.cancel()
 		advance.reload()
 
 		self.assertEqual(advance.paid_amount, 0)
@@ -82,8 +78,7 @@ class TestEmployeeAdvance(IntegrationTestCase):
 		)
 
 		advance = make_employee_advance(claim.employee)
-		journal_entry = make_journal_entry_for_advance(advance)
-		journal_entry.submit()
+		make_payment_entry(advance)
 
 		claim = get_advances_for_claim(claim, advance.name)
 		claim.save()
@@ -94,11 +89,12 @@ class TestEmployeeAdvance(IntegrationTestCase):
 		self.assertEqual(advance.status, "Claimed")
 
 		# advance should not be shown in claims
-		advances = get_advances(claim.employee)
-		advances = [entry.name for entry in advances]
+		advances = get_advances(claim)
+		advances = [entry.employee_advance for entry in advances]
 		self.assertTrue(advance.name not in advances)
 
 		# cancel claim; status should be Paid
+		claim.reload()
 		claim.cancel()
 		advance.reload()
 		self.assertEqual(advance.claimed_amount, 0)
@@ -111,8 +107,7 @@ class TestEmployeeAdvance(IntegrationTestCase):
 		)
 
 		advance = make_employee_advance(claim.employee)
-		journal_entry = make_journal_entry_for_advance(advance)
-		journal_entry.submit()
+		make_payment_entry(advance)
 
 		# PARTLY CLAIMED AND RETURNED status check
 		# 500 Claimed, 500 Returned
@@ -121,8 +116,7 @@ class TestEmployeeAdvance(IntegrationTestCase):
 		)
 
 		advance = make_employee_advance(claim.employee)
-		journal_entry = make_journal_entry_for_advance(advance)
-		journal_entry.submit()
+		make_payment_entry(advance)
 
 		claim = get_advances_for_claim(claim, advance.name, amount=500)
 		claim.save()
@@ -140,7 +134,6 @@ class TestEmployeeAdvance(IntegrationTestCase):
 			advance_account=advance.advance_account,
 			mode_of_payment=advance.mode_of_payment,
 			currency=advance.currency,
-			exchange_rate=advance.exchange_rate,
 		)
 
 		entry = frappe.get_doc(entry)
@@ -152,8 +145,8 @@ class TestEmployeeAdvance(IntegrationTestCase):
 		self.assertEqual(advance.status, "Partly Claimed and Returned")
 
 		# advance should not be shown in claims
-		advances = get_advances(claim.employee)
-		advances = [entry.name for entry in advances]
+		advances = get_advances(claim)
+		advances = [entry.employee_advance for entry in advances]
 		self.assertTrue(advance.name not in advances)
 
 		# Cancel return entry; status should change to PAID
@@ -163,15 +156,14 @@ class TestEmployeeAdvance(IntegrationTestCase):
 		self.assertEqual(advance.status, "Paid")
 
 		# advance should be shown in claims
-		advances = get_advances(claim.employee)
-		advances = [entry.name for entry in advances]
+		advances = get_advances(claim)
+		advances = [entry.employee_advance for entry in advances]
 		self.assertTrue(advance.name in advances)
 
-	def test_repay_unclaimed_amount_from_salary(self):
+	def test_additional_salary_based_advance_repayment_flow(self):
 		employee_name = make_employee("_T@employee.advance", "_Test Company")
 		advance = make_employee_advance(employee_name, {"repay_unclaimed_amount_from_salary": 1})
-		journal_entry = make_journal_entry_for_advance(advance)
-		journal_entry.submit()
+		make_payment_entry(advance)
 
 		args = {"type": "Deduction"}
 		create_salary_component("Advance Salary - Deduction", **args)
@@ -191,9 +183,6 @@ class TestEmployeeAdvance(IntegrationTestCase):
 		additional_salary.insert()
 		additional_salary.submit()
 
-		advance.reload()
-		self.assertEqual(advance.return_amount, 700)
-
 		# additional salary for remaining 300
 		additional_salary = create_return_through_additional_salary(advance)
 		additional_salary.salary_component = "Advance Salary - Deduction"
@@ -202,15 +191,59 @@ class TestEmployeeAdvance(IntegrationTestCase):
 		additional_salary.insert()
 		additional_salary.submit()
 
+		# Employee Advance should not be updated directly
 		advance.reload()
-		self.assertEqual(advance.return_amount, 1000)
-		self.assertEqual(advance.status, "Returned")
-
-		# update advance return amount on additional salary cancellation
-		additional_salary.cancel()
-		advance.reload()
-		self.assertEqual(advance.return_amount, 700)
+		self.assertEqual(advance.return_amount, 0)
 		self.assertEqual(advance.status, "Paid")
+
+		# should not allow scheduling more than available amount
+		additional_salary = create_return_through_additional_salary(advance)
+		additional_salary.salary_component = "Advance Salary - Deduction"
+		additional_salary.payroll_date = nowdate()
+		additional_salary.amount = 100
+
+		self.assertRaises(frappe.ValidationError, additional_salary.insert)
+
+	def test_advance_return_on_payroll_submission(self):
+		company_doc = frappe.get_doc("Company", "_Test Company")
+		employee = make_employee("test_repay_unclaimed_amount@payroll.com", company=company_doc.name)
+
+		advance = make_employee_advance(
+			employee,
+			{"repay_unclaimed_amount_from_salary": 1},
+		)
+		make_payment_entry(advance)
+		advance.reload()
+
+		payroll_details = create_payroll_for_advance_return(employee, company_doc, advance)
+		salary_slip_name = frappe.db.get_value(
+			"Salary Slip",
+			{
+				"payroll_entry": payroll_details.payroll_entry,
+				"employee": employee,
+			},
+			"name",
+		)
+		self.assertIsNotNone(salary_slip_name)
+		salary_slip = frappe.get_doc("Salary Slip", salary_slip_name)
+
+		# Verify advance deduction in salary slip
+		deduction_row = next(
+			(
+				row
+				for row in salary_slip.deductions
+				if row.salary_component == payroll_details.advance_component
+			),
+			None,
+		)
+		self.assertIsNotNone(
+			deduction_row,
+			"Salary advance deduction not found",
+		)
+		self.assertEqual(flt(deduction_row.amount), flt(advance.paid_amount))
+		self.assertEqual(deduction_row.additional_salary, payroll_details.additional_salary)
+		advance.reload()
+		self.assertEqual(advance.status, "Returned")
 
 	def test_payment_entry_against_advance(self):
 		employee_name = make_employee("_T@employee.advance", "_Test Company")
@@ -218,7 +251,7 @@ class TestEmployeeAdvance(IntegrationTestCase):
 
 		pe = make_payment_entry(advance, 700)
 		advance.reload()
-		self.assertEqual(advance.status, "Unpaid")
+		self.assertEqual(advance.status, "Partially Paid")
 		self.assertEqual(advance.paid_amount, 700)
 
 		pe = make_payment_entry(advance, 300)
@@ -228,14 +261,57 @@ class TestEmployeeAdvance(IntegrationTestCase):
 
 		pe.cancel()
 		advance.reload()
-		self.assertEqual(advance.status, "Unpaid")
+		self.assertEqual(advance.status, "Partially Paid")
 		self.assertEqual(advance.paid_amount, 700)
+
+	def test_expense_claim_against_partially_paid_advance(self):
+		employee_name = make_employee("_T@employee.advance", "_Test Company")
+		advance = make_employee_advance(employee_name)
+		make_payment_entry(advance, 700)
+		advance.reload()
+
+		self.assertEqual(advance.status, "Partially Paid")
+
+		currency, cost_center = frappe.db.get_value(
+			"Company", "_Test Company", ["default_currency", "cost_center"]
+		)
+		claim = get_expense_claim(advance.name)  # create claim from employee advance form
+		claim.update(
+			{
+				"payable_account": get_payable_account("_Test Company"),
+				"currency": currency,
+				"exchange_rate": 1,
+				"approval_status": "Approved",
+			}
+		)
+		claim.append(
+			"expenses",
+			{
+				"expense_type": "Travel",
+				"default_account": "Travel Expenses - _TC",
+				"amount": 1000,
+				"sanctioned_amount": 1000,
+				"cost_center": cost_center,
+			},
+		)
+		claim.save()
+		claim.submit()
+
+		self.assertEqual(len(claim.advances), 1)
+		self.assertEqual(claim.advances[0].employee_advance, advance.name)
+		self.assertEqual(claim.advances[0].advance_paid, 700)
+		self.assertEqual(claim.advances[0].allocated_amount, 700)
+		self.assertEqual(claim.total_claimed_amount, 1000)
+		self.assertEqual(claim.grand_total, 300)
+
+		advance.reload()
+		self.assertEqual(advance.claimed_amount, 700)
+		self.assertEqual(advance.status, "Claimed")
 
 	def test_precision(self):
 		employee_name = make_employee("_T@employee.advance", "_Test Company")
 		advance = make_employee_advance(employee_name)
-		journal_entry = make_journal_entry_for_advance(advance)
-		journal_entry.submit()
+		make_payment_entry(advance)
 
 		# PARTLY CLAIMED AND RETURNED
 		payable_account = get_payable_account("_Test Company")
@@ -258,7 +334,6 @@ class TestEmployeeAdvance(IntegrationTestCase):
 			advance_account=advance.advance_account,
 			mode_of_payment=advance.mode_of_payment,
 			currency=advance.currency,
-			exchange_rate=advance.exchange_rate,
 		)
 
 		entry = frappe.get_doc(entry)
@@ -275,6 +350,8 @@ class TestEmployeeAdvance(IntegrationTestCase):
 
 		advance1 = make_employee_advance(employee_name)
 		make_payment_entry(advance1, 500)
+		advance1.reload()
+		self.assertEqual(advance1.status, "Partially Paid")
 
 		advance2 = make_employee_advance(employee_name)
 		# 1000 - 500
@@ -285,7 +362,9 @@ class TestEmployeeAdvance(IntegrationTestCase):
 		# (1000 - 500) + (1000 - 700)
 		self.assertEqual(advance3.pending_amount, 800)
 
-	@change_settings("HR Settings", {"unlink_payment_on_cancellation_of_employee_advance": True})
+	@HRMSTestSuite.change_settings(
+		"HR Settings", {"unlink_payment_on_cancellation_of_employee_advance": True}
+	)
 	def test_unlink_payment_entries(self):
 		employee_name = make_employee("_T@employee.advance", "_Test Company")
 		self.assertTrue(frappe.db.exists("Employee", employee_name))
@@ -306,17 +385,11 @@ class TestEmployeeAdvance(IntegrationTestCase):
 	def test_employee_advance_when_different_company_currency(self):
 		employee = make_employee("test_adv_in_company_currency@example.com", "_Test Company")
 
-		account = create_account(
-			account_name="Employee Advance (USD)",
-			parent_account="Accounts Receivable - _TC",
-			company="_Test Company",
-			account_currency="USD",
-			account_type="Receivable",
+		advance_account = create_advance_account("Employee Advance (USD)", "USD")
+
+		advance = make_employee_advance(
+			employee, {"currency": "USD", "exchange_rate": 80, "advance_account": advance_account}
 		)
-
-		frappe.db.set_value("Company", "_Test Company", "default_employee_advance_account", account)
-
-		advance = make_employee_advance(employee, {"currency": "USD", "exchange_rate": 80})
 		make_payment_entry(advance, 1000)
 		advance.reload()
 
@@ -325,15 +398,9 @@ class TestEmployeeAdvance(IntegrationTestCase):
 
 	def test_employee_advance_when_different_account_currency(self):
 		employee = make_employee("test_adv_in_account_currency@example.com", "_Test Company")
-		account = create_account(
-			account_name="Employee Advance (USD)",
-			parent_account="Accounts Receivable - _TC",
-			company="_Test Company",
-			account_currency="USD",
-			account_type="Receivable",
-		)
+		advance_account = create_advance_account("Employee Advance (USD)", "USD")
 
-		frappe.db.set_value("Company", "_Test Company", "default_employee_advance_account", account)
+		frappe.db.set_value("Company", "_Test Company", "default_employee_advance_account", advance_account)
 		advance = make_employee_advance(employee, {"currency": "INR", "exchange_rate": 1})
 		make_payment_entry(advance, 1000)
 		advance.reload()
@@ -343,17 +410,10 @@ class TestEmployeeAdvance(IntegrationTestCase):
 
 	def test_employee_advance_when_different_advance_currency(self):
 		employee = make_employee("test_adv_in_advance_currency@example.com", "_Test Company")
-
-		advance = make_employee_advance(employee, {"currency": "USD", "exchange_rate": 80})
-		frappe.db.set_value(
-			"Company", "_Test Company", "default_employee_advance_account", "_Test Employee Advance - _TC"
+		advance = make_employee_advance(
+			employee, {"currency": "USD", "exchange_rate": 80}, do_not_submit=True
 		)
-		make_payment_entry(advance)
-
-		advance.reload()
-
-		self.assertEqual(advance.status, "Paid")
-		self.assertEqual(advance.paid_amount, 1000)
+		self.assertRaises(frappe.ValidationError, advance.save)
 
 	def update_company_in_fiscal_year(self):
 		fy_entries = frappe.get_all("Fiscal Year")
@@ -364,73 +424,196 @@ class TestEmployeeAdvance(IntegrationTestCase):
 				fiscal_year.append("companies", {"company": "_Test Company"})
 				fiscal_year.save()
 
+	def test_multicurrency_advance(self):
+		advance_account = create_advance_account("Employee Advance (USD)", "USD")
+		employee = make_employee(
+			"test_adv_in_multicurrency@example.com",
+			"_Test Company",
+			salary_currency="USD",
+			employee_advance_account=advance_account,
+		)
+		advance = make_employee_advance(employee)
+		self.assertEqual(advance.status, "Unpaid")
 
-def make_journal_entry_for_advance(advance):
-	journal_entry = frappe.get_doc(make_bank_entry("Employee Advance", advance.name))
-	journal_entry.cheque_no = "123123"
-	journal_entry.cheque_date = nowdate()
-	journal_entry.save()
+		payment_entry = make_payment_entry(advance, advance.advance_amount)
+		advance.reload()
+		self.assertEqual(advance.status, "Paid")
+		self.assertEqual(payment_entry.received_amount, advance.paid_amount)
 
-	return journal_entry
+		expected_base_paid = flt(
+			advance.paid_amount * payment_entry.transaction_exchange_rate,
+			advance.precision("base_paid_amount"),
+		)
+		self.assertEqual(advance.base_paid_amount, expected_base_paid)
+		self.assertEqual(payment_entry.paid_amount, expected_base_paid)
+
+	def test_no_exchange_gain_loss_for_same_currency_advance_payment(self):
+		from hrms.overrides.employee_payment_entry import get_payment_entry_for_employee
+
+		gain_loss_account = frappe.db.get_value("Company", "_Test Company", "exchange_gain_loss_account")
+		frappe.db.set_value("Company", "_Test Company", "exchange_gain_loss_account", None)
+
+		try:
+			employee_name = make_employee("_T@employee.advance", "_Test Company")
+			advance = make_employee_advance(employee_name)
+
+			# should not raise error even without exchange_gain_loss_account set at time of payment
+			pe = get_payment_entry_for_employee(advance.doctype, advance.name)
+
+			self.assertEqual(flt(pe.source_exchange_rate), 1.0)
+			self.assertEqual(flt(pe.target_exchange_rate), 1.0)
+			self.assertFalse(any(d.is_exchange_gain_loss for d in pe.deductions))
+		finally:
+			frappe.db.set_value("Company", "_Test Company", "exchange_gain_loss_account", gain_loss_account)
+
+	def test_status_on_discard(self):
+		employee_name = make_employee("Test_status@employee.advance", "_Test Company")
+		advance = make_employee_advance(employee_name, do_not_submit=True)
+		advance.insert()
+		advance.reload()
+		self.assertEqual(advance.status, "Draft")
+		advance.discard()
+		advance.reload()
+		self.assertEqual(advance.status, "Cancelled")
+
+
+def manual_journal_entry_for_advance(advance) -> dict:
+	doc = frappe.get_doc("Employee Advance", advance.name)
+	payment_account = get_same_currency_bank_cash_account(doc.company, doc.currency, doc.mode_of_payment)
+
+	je = frappe.new_doc("Journal Entry")
+	je.posting_date = nowdate()
+	je.voucher_type = "Bank Entry"
+	je.company = doc.company
+	je.remark = "Payment against Employee Advance: " + advance.name + "\n" + doc.purpose
+	je.multi_currency = 1 if doc.currency != erpnext.get_company_currency(doc.company) else 0
+
+	je.append(
+		"accounts",
+		{
+			"account": doc.advance_account,
+			"account_currency": doc.currency,
+			"debit_in_account_currency": flt(doc.advance_amount),
+			"reference_type": "Employee Advance",
+			"reference_name": doc.name,
+			"party_type": "Employee",
+			"cost_center": erpnext.get_default_cost_center(doc.company),
+			"party": doc.employee,
+			"is_advance": "Yes",
+		},
+	)
+
+	je.append(
+		"accounts",
+		{
+			"account": payment_account.account or payment_account.name,
+			"cost_center": erpnext.get_default_cost_center(doc.company),
+			"credit_in_account_currency": flt(doc.advance_amount),
+			"account_currency": doc.currency,
+			"account_type": payment_account.account_type,
+		},
+	)
+	je.cheque_no = "123123"
+	je.cheque_date = nowdate()
+	je.save()
+	return je
 
 
 def make_payment_entry(advance, amount=None):
 	from hrms.overrides.employee_payment_entry import get_payment_entry_for_employee
 
-	payment_entry = get_payment_entry_for_employee(advance.doctype, advance.name)
+	payment_entry = get_payment_entry_for_employee(advance.doctype, advance.name, party_amount=amount)
 
 	payment_entry.reference_no = "1"
 	payment_entry.reference_date = nowdate()
-	if amount:
-		payment_entry.references[0].allocated_amount = amount
 	payment_entry.submit()
 	return payment_entry
 
 
-def make_employee_advance(employee_name, args=None):
+def make_employee_advance(employee_name, args=None, do_not_submit=False):
+	emp_details = frappe.db.get_value(
+		"Employee", employee_name, ["salary_currency", "employee_advance_account"], as_dict=True
+	)
 	doc = frappe.new_doc("Employee Advance")
 	doc.employee = employee_name
 	doc.company = "_Test Company"
 	doc.purpose = "For site visit"
-	doc.currency = erpnext.get_company_currency("_Test company")
-	doc.exchange_rate = 1
+	doc.currency = emp_details.salary_currency or erpnext.get_company_currency("_Test company")
 	doc.advance_amount = 1000
 	doc.posting_date = nowdate()
-	doc.advance_account = "_Test Employee Advance - _TC"
+	doc.advance_account = emp_details.employee_advance_account or "_Test Employee Advance - _TC"
+	account_type = frappe.db.get_value("Account", "_Test Employee Advance - _TC", "account_type")
+	if not account_type:
+		frappe.db.set_value("Account", "_Test Employee Advance - _TC", "account_type", "Receivable")
 
 	if args:
 		doc.update(args)
 
+	if do_not_submit:
+		return doc
 	doc.insert()
 	doc.submit()
-
 	return doc
 
 
 def get_advances_for_claim(claim, advance_name, amount=None):
-	advances = get_advances(claim.employee, advance_name)
-
-	for entry in advances:
+	advances = get_advances(claim, advance_name)
+	claim.advances = []
+	for advance in advances:
 		if amount:
-			allocated_amount = amount
-		else:
-			allocated_amount = get_allocation_amount(
-				paid_amount=entry.paid_amount,
-				claimed_amount=entry.claimed_amount,
-				return_amount=entry.return_amount,
-			)
-
-		claim.append(
-			"advances",
-			{
-				"employee_advance": entry.name,
-				"posting_date": entry.posting_date,
-				"advance_account": entry.advance_account,
-				"advance_paid": entry.paid_amount,
-				"return_amount": entry.return_amount,
-				"unclaimed_amount": entry.paid_amount - entry.claimed_amount,
-				"allocated_amount": allocated_amount,
-			},
-		)
-
+			advance.allocated_amount = amount
+		claim.append("advances", advance)
 	return claim
+
+
+def create_advance_account(account_name, account_currency):
+	return create_account(
+		account_name=account_name,
+		parent_account="Accounts Receivable - _TC",
+		company="_Test Company",
+		account_currency=account_currency,
+		account_type="Receivable",
+	)
+
+
+def create_payroll_for_advance_return(employee, company, advance, return_amount=None):
+	# Advance deduction component
+	component = create_salary_component(
+		"Advance Salary",
+		**{"type": "Deduction"},
+	)
+	component.append(
+		"accounts",
+		{
+			"company": company.name,
+			"account": "Employee Advances - _TC",
+		},
+	)
+	component.save()
+
+	setup_salary_structure(employee, company)
+
+	# Create Additional Salary for repayment
+	additional_salary = create_return_through_additional_salary(advance)
+	additional_salary.salary_component = component.name
+	additional_salary.payroll_date = nowdate()
+	additional_salary.amount = return_amount or advance.paid_amount
+	additional_salary.submit()
+
+	# Process payroll
+	dates = get_start_end_dates("Monthly", nowdate())
+	payroll_entry = make_payroll_entry(
+		start_date=dates.start_date,
+		end_date=dates.end_date,
+		payable_account=company.default_payroll_payable_account,
+		currency=company.default_currency,
+		company=company.name,
+		cost_center="Main - _TC",
+	)
+	return _dict(
+		{
+			"payroll_entry": payroll_entry.name,
+			"advance_component": component.name,
+			"additional_salary": additional_salary.name,
+		}
+	)

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
@@ -11,132 +11,223 @@ from frappe.utils import getdate
 
 
 class EmployeeAttendanceTool(Document):
-    pass
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		branch: DF.Link | None
+		company: DF.Link | None
+		date: DF.Date | None
+		department: DF.Link | None
+		designation: DF.Link | None
+		early_exit: DF.Check
+		employee_grade: DF.Link | None
+		employment_type: DF.Link | None
+		filter_by_shift: DF.Check
+		half_day_status: DF.Literal["Present", "Absent"]
+		late_entry: DF.Check
+		shift: DF.Link | None
+		status: DF.Literal["", "Present", "Absent", "Half Day", "Work From Home"]
+	# end: auto-generated types
+
+	def save(self):
+		return
+
+	@staticmethod
+	def get_list():
+		pass
+
+	@staticmethod
+	def get_count():
+		pass
+
+	@staticmethod
+	def get_stats():
+		pass
+
+	def db_insert(self):
+		pass
+
+	def db_update(self):
+		pass
+
+	def delete(self):
+		pass
 
 
 @frappe.whitelist()
 def get_employees(
-    date: str | datetime.date,
-    department: str | None = None,
-    branch: str | None = None,
-    company: str | None = None,
-    employment_type: str | None = None,
-    designation: str | None = None,
-    employee_grade: str | None = None,
+	date: str | datetime.date,
+	department: str | None = None,
+	branch: str | None = None,
+	company: str | None = None,
+	employment_type: str | None = None,
+	designation: str | None = None,
+	employee_grade: str | None = None,
+	shift: str | None = None,
+	filter_by_shift: bool | None = None,
 ) -> dict[str, list]:
-    filters = {"status": "Active", "date_of_joining": ["<=", date]}
+	filters = {"status": "Active", "date_of_joining": ["<=", date]}
 
-    for field, value in {
-        "department": department,
-        "branch": branch,
-        "company": company,
-        "employment_type": employment_type,
-        "designation": designation,
-        "employee_grade": employee_grade,
-    }.items():
-        if value:
-            filters[field] = value
-    # list of all employees
-    employee_list = frappe.get_list(
-        "Employee",
-        fields=["employee", "employee_name"],
-        filters=filters,
-        order_by="employee_name",
-    )
-    # marked attendance
-    attendance_list = frappe.get_list(
-        "Attendance",
-        fields=["employee", "employee_name", "status", "shift", "leave_type"],
-        filters={
-            "attendance_date": date,
-            "docstatus": 1,
-            "modify_half_day_status": 0,
-        },
-        order_by="employee_name",
-    )
-    half_day_attendance_list = frappe.get_list(
-        "Attendance",
-        fields=["employee", "employee_name"],
-        filters={
-            "attendance_date": date,
-            "docstatus": 1,
-            "modify_half_day_status": 1,
-            "leave_type": ("is", "set"),
-        },
-        order_by="employee_name",
-    )
-    unmarked_attendance = _get_unmarked_attendance(
-        employee_list, [*attendance_list, *half_day_attendance_list]
-    )
-    return {
-        "marked": attendance_list,
-        "half_day_marked": half_day_attendance_list,
-        "unmarked": unmarked_attendance,
-    }
+	for field, value in {
+		"department": department,
+		"branch": branch,
+		"company": company,
+		"employment_type": employment_type,
+		"designation": designation,
+		"grade": employee_grade,
+	}.items():
+		if value:
+			filters[field] = value
+	# list of all employees
+	employee_list = frappe.get_list(
+		"Employee",
+		fields=["employee", "employee_name"],
+		filters=filters,
+		order_by="employee_name",
+	)
+	# marked attendance
+	attendance_list = frappe.get_list(
+		"Attendance",
+		fields=["employee", "employee_name", "status", "shift", "leave_type"],
+		filters={
+			"attendance_date": date,
+			"docstatus": 1,
+			"modify_half_day_status": 0,
+		},
+		order_by="employee_name",
+	)
+	half_day_attendance_list = frappe.get_list(
+		"Attendance",
+		fields=["employee", "employee_name"],
+		filters={
+			"attendance_date": date,
+			"docstatus": 1,
+			"modify_half_day_status": 1,
+			"leave_type": ("is", "set"),
+		},
+		order_by="employee_name",
+	)
+	unmarked_attendance = _get_unmarked_attendance(
+		employee_list, [*attendance_list, *half_day_attendance_list]
+	)
+	if filter_by_shift:
+		unmarked_attendance = _get_unmarked_attendance_with_shift(unmarked_attendance, shift, date)
+	return {
+		"marked": attendance_list,
+		"half_day_marked": half_day_attendance_list,
+		"unmarked": unmarked_attendance,
+	}
 
 
-def _get_unmarked_attendance(
-    employee_list: list[dict], attendance_list: list[dict]
-) -> list[dict]:
-    marked_employees = [entry.employee for entry in attendance_list]
-    unmarked_attendance = []
+def _get_unmarked_attendance(employee_list: list[dict], attendance_list: list[dict]) -> list[dict]:
+	marked_employees = [entry.employee for entry in attendance_list]
+	unmarked_attendance = []
 
-    for entry in employee_list:
-        if entry.employee not in marked_employees:
-            unmarked_attendance.append(entry)
+	for entry in employee_list:
+		if entry.employee not in marked_employees:
+			unmarked_attendance.append(entry)
 
-    return unmarked_attendance
+	return unmarked_attendance
+
+
+def _get_unmarked_attendance_with_shift(unmarked_attendance, shift, date):
+	# Fetch employees based on Shift Assignment
+	shift_assigned_employees = frappe.get_list(
+		"Shift Assignment",
+		filters={
+			"shift_type": shift,
+			"start_date": ["<=", frappe.utils.getdate(date)],
+		},
+		fields=["employee"],
+	)
+	# Fetch employees based on default shifts
+	default_shift_employees = frappe.get_list(
+		"Employee",
+		filters={
+			"default_shift": shift,
+		},
+		fields=["employee"],
+	)
+
+	all_employees_with_shift = shift_assigned_employees + default_shift_employees
+	distinct_employees_with_shift = {emp["employee"] for emp in all_employees_with_shift}
+
+	# Filter unmarked attendance based on assigned employees
+	shiftwise_unmarked_attendance = []
+	for emp in unmarked_attendance:
+		if emp["employee"] in distinct_employees_with_shift:
+			shiftwise_unmarked_attendance.append(emp)
+
+	return shiftwise_unmarked_attendance
 
 
 @frappe.whitelist()
 def mark_employee_attendance(
-    employee_list: list | str,
-    status: str,
-    date: str | datetime.date,
-    leave_type: str | None = None,
-    company: str | None = None,
-    late_entry: int | None = None,
-    early_exit: int | None = None,
-    shift: str | None = None,
-    mark_half_day: bool | None = False,
-    half_day_status: str | None = None,
-    half_day_employee_list: list | str | None = None,
+	employee_list: list | str,
+	status: str,
+	date: str | datetime.date,
+	leave_type: str | None = None,
+	company: str | None = None,
+	late_entry: int | None = None,
+	early_exit: int | None = None,
+	shift: str | None = None,
+	mark_half_day: bool | None = False,
+	half_day_status: str | None = None,
+	half_day_employee_list: list | str | None = None,
 ) -> None:
-    if isinstance(employee_list, str):
-        employee_list = json.loads(employee_list)
+	if isinstance(employee_list, str):
+		employee_list = json.loads(employee_list)
 
-    for employee in employee_list:
-        leave_type = None
-        if status == "On Leave" and leave_type:
-            leave_type = leave_type
+	for employee in employee_list:
+		leave_type = None
+		if status == "On Leave" and leave_type:
+			leave_type = leave_type
 
-        attendance = frappe.get_doc(
-            dict(
-                doctype="Attendance",
-                employee=employee,
-                attendance_date=getdate(date),
-                status=status,
-                leave_type=leave_type,
-                late_entry=late_entry,
-                early_exit=early_exit,
-                shift=shift,
-            )
-        )
-        attendance.insert()
-        attendance.submit()
-    if mark_half_day:
-        if isinstance(half_day_employee_list, str):
-            half_day_employee_list = json.loads(half_day_employee_list)
-        Attendance = frappe.qb.DocType("Attendance")
-        for employee in half_day_employee_list:
-            frappe.qb.update(Attendance).where(
-                (Attendance.employee == employee) & (Attendance.attendance_date == date)
-            ).set(Attendance.half_day_status, half_day_status).set(
-                Attendance.shift, shift
-            ).set(
-                Attendance.late_entry, late_entry
-            ).set(
-                Attendance.early_exit, early_exit
-            ).set(
-                Attendance.modify_half_day_status, 0
-            ).run()
+		attendance = frappe.get_doc(
+			dict(
+				doctype="Attendance",
+				employee=employee,
+				attendance_date=getdate(date),
+				status=status,
+				leave_type=leave_type,
+				late_entry=late_entry,
+				early_exit=early_exit,
+				shift=shift,
+			)
+		)
+		attendance.insert()
+		attendance.submit()
+	if mark_half_day:
+		frappe.has_permission("Attendance", "write", throw=True)
+		if isinstance(half_day_employee_list, str):
+			half_day_employee_list = json.loads(half_day_employee_list)
+
+		eligible_attendance = frappe.get_list(
+			"Attendance",
+			filters={
+				"employee": ["in", half_day_employee_list],
+				"attendance_date": date,
+				"docstatus": 1,
+			},
+			fields=["name", "employee"],
+			limit=0,
+		)
+		attendance_map = {d.employee: d.name for d in eligible_attendance}
+
+		Attendance = frappe.qb.DocType("Attendance")
+		for employee in half_day_employee_list:
+			attendance_name = attendance_map.get(employee)
+			if attendance_name:
+				frappe.has_permission("Attendance", "write", attendance_name, throw=True)
+				frappe.qb.update(Attendance).where(
+					(Attendance.employee == employee)
+					& (Attendance.attendance_date == date)
+					& (Attendance.docstatus == 1)
+				).set(Attendance.half_day_status, half_day_status).set(Attendance.shift, shift).set(
+					Attendance.late_entry, late_entry or 0
+				).set(Attendance.early_exit, early_exit or 0).set(Attendance.modify_half_day_status, 0).run()

--- a/hrms/hr/doctype/employee_attendance_tool/test_employee_attendance_tool.py
+++ b/hrms/hr/doctype/employee_attendance_tool/test_employee_attendance_tool.py
@@ -2,266 +2,309 @@
 # See license.txt
 
 import frappe
-from frappe.tests import IntegrationTestCase
 from frappe.utils import add_days, getdate
 
+from erpnext.setup.doctype.employee.employee import is_holiday
 from erpnext.setup.doctype.employee.test_employee import make_employee
 
 from hrms.hr.doctype.attendance.attendance import mark_attendance
 from hrms.hr.doctype.employee_attendance_tool.employee_attendance_tool import (
-    _get_unmarked_attendance_with_shift,
-    get_employees,
-    mark_employee_attendance,
+	_get_unmarked_attendance_with_shift,
+	get_employees,
+	mark_employee_attendance,
+)
+from hrms.hr.doctype.holiday_list_assignment.test_holiday_list_assignment import (
+	create_holiday_list_assignment,
 )
 from hrms.hr.doctype.leave_type.test_leave_type import create_leave_type
 from hrms.hr.doctype.shift_type.test_shift_type import setup_shift_type
 from hrms.payroll.doctype.salary_slip.test_salary_slip import make_leave_application
+from hrms.tests.utils import HRMSTestSuite
 
 
-class TestEmployeeAttendanceTool(IntegrationTestCase):
-    def setUp(self):
-        frappe.db.delete("Attendance")
+class TestEmployeeAttendanceTool(HRMSTestSuite):
+	def setUp(self):
+		frappe.db.delete("Attendance")
 
-        self.employee1 = make_employee(
-            "test_present@example.com", company="_Test Company"
-        )
-        self.employee2 = make_employee(
-            "test_absent@example.com", company="_Test Company"
-        )
-        self.employee3 = make_employee(
-            "test_unmarked@example.com", company="_Test Company"
-        )
+		self.employee1 = make_employee("test_present@example.com", company="_Test Company")
+		self.employee2 = make_employee("test_absent@example.com", company="_Test Company")
+		self.employee3 = make_employee("test_unmarked@example.com", company="_Test Company")
 
-        self.employee4 = make_employee(
-            "test_filter@example.com", company="_Test Company 1"
-        )
+		self.employee4 = make_employee("test_filter@example.com", company="_Test Company 1")
+		create_holiday_list_assignment("Company", "_Test Company 1")
 
-    def test_get_employee_attendance(self):
-        date = getdate("28-02-2023")
-        mark_attendance(self.employee1, date, "Present")
-        mark_attendance(self.employee2, date, "Absent")
+	def test_get_employee_attendance(self):
+		date = getdate("28-02-2023")
+		mark_attendance(self.employee1, date, "Present")
+		mark_attendance(self.employee2, date, "Absent")
 
-        employees = get_employees(date, company="_Test Company")
+		employees = get_employees(date, company="_Test Company")
 
-        marked_employees = employees["marked"]
-        unmarked_employees = [entry.employee for entry in employees["unmarked"]]
+		marked_employees = employees["marked"]
+		unmarked_employees = [entry.employee for entry in employees["unmarked"]]
 
-        # absent
-        self.assertEqual(marked_employees[0].get("employee"), self.employee2)
-        # present
-        self.assertEqual(marked_employees[1].get("employee"), self.employee1)
-        # unmarked
-        self.assertIn(self.employee3, unmarked_employees)
-        # employee from a different company
-        self.assertNotIn(self.employee4, unmarked_employees)
+		# absent
+		self.assertEqual(marked_employees[0].get("employee"), self.employee2)
+		# present
+		self.assertEqual(marked_employees[1].get("employee"), self.employee1)
+		# unmarked
+		self.assertIn(self.employee3, unmarked_employees)
+		# employee from a different company
+		self.assertNotIn(self.employee4, unmarked_employees)
 
-    def test_mark_employee_attendance(self):
-        shift = setup_shift_type(
-            shift_type="Shift 1", start_time="08:00:00", end_time="10:00:00"
-        )
-        date = getdate("28-02-2023")
+	def test_mark_employee_attendance(self):
+		shift = setup_shift_type(shift_type="Shift 1", start_time="08:00:00", end_time="10:00:00")
+		date = getdate("28-02-2023")
 
-        mark_employee_attendance(
-            [self.employee1, self.employee2],
-            "Present",
-            date,
-            shift=shift.name,
-            late_entry=1,
-        )
+		mark_employee_attendance(
+			[self.employee1, self.employee2],
+			"Present",
+			date,
+			shift=shift.name,
+			late_entry=1,
+		)
 
-        attendance = frappe.db.get_value(
-            "Attendance",
-            {"employee": self.employee1, "attendance_date": date},
-            ["status", "shift", "late_entry"],
-            as_dict=True,
-        )
+		attendance = frappe.db.get_value(
+			"Attendance",
+			{"employee": self.employee1, "attendance_date": date},
+			["status", "shift", "late_entry"],
+			as_dict=True,
+		)
 
-        self.assertEqual(attendance.status, "Present")
-        self.assertEqual(attendance.shift, shift.name)
-        self.assertEqual(attendance.late_entry, 1)
+		self.assertEqual(attendance.status, "Present")
+		self.assertEqual(attendance.shift, shift.name)
+		self.assertEqual(attendance.late_entry, 1)
 
-    def test_get_employees_for_half_day_attendance(self):
-        # only half day attendance created from leave type should be fetched to update in the tool
-        employee = frappe.get_doc("Employee", self.employee1)
-        leave_type = create_leave_type(
-            leave_type="_Test Employee Attendance Tool", include_holidays=0
-        )
-        frappe.get_doc(
-            {
-                "doctype": "Leave Allocation",
-                "employee": employee.name,
-                "employee_name": employee.employee_name,
-                "leave_type": leave_type.name,
-                "from_date": add_days(getdate(), -2),
-                "new_leaves_allocated": 15,
-                "carry_forward": 0,
-                "to_date": add_days(getdate(), 30),
-            }
-        ).submit()
-        make_leave_application(
-            employee=employee.name,
-            from_date=getdate(),
-            to_date=getdate(),
-            leave_type=leave_type.name,
-            half_day=1,
-            half_day_date=getdate(),
-        )
-        mark_attendance(
-            self.employee2,
-            attendance_date=getdate(),
-            status="Half Day",
-            half_day_status="Absent",
-        )
-        total_employees = get_employees(getdate(), company="_Test Company")
-        half_marked_employees = total_employees.get("half_day_marked")
-        self.assertEqual(len(half_marked_employees), 1)
-        self.assertEqual(
-            half_marked_employees[0].get("employee_name"), employee.employee_name
-        )
+	def test_get_employees_for_half_day_attendance(self):
+		# only half day attendance created from leave type should be fetched to update in the tool
+		employee = frappe.get_doc("Employee", self.employee1)
+		leave_type = create_leave_type(leave_type="_Test Employee Attendance Tool", include_holidays=0)
+		date = getdate()
+		while is_holiday(employee=employee.name, date=date):
+			date = add_days(date, -1)
+		frappe.get_doc(
+			{
+				"doctype": "Leave Allocation",
+				"employee": employee.name,
+				"employee_name": employee.employee_name,
+				"leave_type": leave_type.name,
+				"from_date": add_days(date, -2),
+				"new_leaves_allocated": 15,
+				"carry_forward": 0,
+				"to_date": add_days(getdate(), 30),
+			}
+		).submit()
+		make_leave_application(
+			employee=employee.name,
+			from_date=date,
+			to_date=date,
+			leave_type=leave_type.name,
+			half_day=1,
+			half_day_date=date,
+		)
+		mark_attendance(self.employee2, attendance_date=date, status="Half Day", half_day_status="Absent")
+		total_employees = get_employees(date, company="_Test Company")
+		half_marked_employees = total_employees.get("half_day_marked")
+		self.assertEqual(len(half_marked_employees), 1)
+		self.assertEqual(half_marked_employees[0].get("employee_name"), employee.employee_name)
 
-    def test_update_half_day_attendance(self):
-        shift = setup_shift_type(
-            shift_type="Test Attendance Tool",
-            start_time="08:00:00",
-            end_time="12:00:00",
-        )
-        employee4 = frappe.get_doc("Employee", self.employee4)
-        employee2 = frappe.get_doc("Employee", self.employee2)
-        leave_type = create_leave_type(
-            leave_type="_Test Employee Attendance Tool", include_holidays=0
-        )
-        date = add_days(getdate(), -1)
-        create_leave_allocation(employee2, leave_type)
-        create_leave_allocation(employee4, leave_type)
-        make_leave_application(
-            employee=employee2.name,
-            from_date=date,
-            to_date=date,
-            leave_type=leave_type.name,
-            half_day=1,
-            half_day_date=date,
-        )
-        make_leave_application(
-            employee=employee4.name,
-            from_date=date,
-            to_date=date,
-            leave_type=leave_type.name,
-            half_day=1,
-            half_day_date=date,
-        )
+	def test_update_half_day_attendance(self):
+		shift = setup_shift_type(
+			shift_type="Test Attendance Tool", start_time="08:00:00", end_time="12:00:00"
+		)
+		employee4 = frappe.get_doc("Employee", self.employee4)
+		employee2 = frappe.get_doc("Employee", self.employee2)
+		leave_type = create_leave_type(leave_type="_Test Employee Attendance Tool", include_holidays=0)
+		date = add_days(getdate(), -1)
+		while is_holiday(employee=employee2.name, date=date) or is_holiday(
+			employee=employee4.name, date=date
+		):
+			date = add_days(date, -1)
+		create_leave_allocation(employee2, leave_type, date)
+		create_leave_allocation(employee4, leave_type, date)
+		make_leave_application(
+			employee=employee2.name,
+			from_date=date,
+			to_date=date,
+			leave_type=leave_type.name,
+			half_day=1,
+			half_day_date=date,
+		)
+		make_leave_application(
+			employee=employee4.name,
+			from_date=date,
+			to_date=date,
+			leave_type=leave_type.name,
+			half_day=1,
+			half_day_date=date,
+		)
 
-        mark_employee_attendance(
-            employee_list=[self.employee1, self.employee3],
-            status="Present",
-            date=date,
-            shift=shift.name,
-            late_entry=1,
-            early_exit=0,
-            mark_half_day=True,
-            half_day_status="Present",
-            half_day_employee_list=[employee2.name, employee4.name],
-        )
-        attendances = frappe.get_all(
-            "Attendance",
-            filters={"attendance_date": date},
-            fields=[
-                "employee",
-                "status",
-                "half_day_status",
-                "shift",
-                "late_entry",
-                "early_exit",
-            ],
-        )
-        self.assertEqual(len(attendances), 4)
-        for attendance in attendances:
-            if attendance.get("employee") in (self.employee1, self.employee3):
-                self.assertEqual(attendance.status, "Present")
-                self.assertIsNone(attendance.half_day_status)
-            if attendance.get("employee") in (self.employee2, self.employee4):
-                self.assertEqual(attendance.status, "Half Day")
-                self.assertEqual(attendance.half_day_status, "Present")
-            self.assertEqual(attendance.shift, shift.name)
+		mark_employee_attendance(
+			employee_list=[self.employee1, self.employee3],
+			status="Present",
+			date=date,
+			shift=shift.name,
+			late_entry=1,
+			early_exit=0,
+			mark_half_day=True,
+			half_day_status="Present",
+			half_day_employee_list=[employee2.name, employee4.name],
+		)
+		attendances = frappe.get_all(
+			"Attendance",
+			filters={"attendance_date": date},
+			fields=["employee", "status", "half_day_status", "shift", "late_entry", "early_exit"],
+		)
+		self.assertEqual(len(attendances), 4)
+		for attendance in attendances:
+			if attendance.get("employee") in (self.employee1, self.employee3):
+				self.assertEqual(attendance.status, "Present")
+				self.assertIsNone(attendance.half_day_status)
+			if attendance.get("employee") in (self.employee2, self.employee4):
+				self.assertEqual(attendance.status, "Half Day")
+				self.assertEqual(attendance.half_day_status, "Present")
+			self.assertEqual(attendance.shift, shift.name)
 
-    def test_get_unmarked_attendance_with_shift(self):
-        self.shift = setup_shift_type(
-            shift_type="Shift 1", start_time="08:00:00", end_time="10:00:00"
-        )
-        self.employee1 = frappe.get_doc(
-            {
-                "doctype": "Employee",
-                "first_name": "Morning Shift Assigned",
-                "employee": "EMP001",
-                "date_of_birth": "1992-01-01",
-                "date_of_joining": "2023-01-01",
-                "default_shift": "",
-                "gender": "Male",
-            }
-        ).insert()
+	def test_get_unmarked_attendance_with_shift(self):
+		self.shift = setup_shift_type(shift_type="Shift 1", start_time="08:00:00", end_time="10:00:00")
+		self.employee1 = frappe.get_doc(
+			{
+				"doctype": "Employee",
+				"first_name": "Morning Shift Assigned",
+				"employee": "EMP001",
+				"date_of_birth": "1992-01-01",
+				"date_of_joining": "2023-01-01",
+				"default_shift": "",
+				"gender": "Male",
+				"company": "_Test Company",
+			}
+		).insert()
 
-        self.employee2 = frappe.get_doc(
-            {
-                "doctype": "Employee",
-                "first_name": "Test Default Shift",
-                "employee": "EMP002",
-                "date_of_birth": "1992-01-01",
-                "date_of_joining": "2023-01-01",
-                "default_shift": self.shift.name,
-                "gender": "Male",
-            }
-        ).insert()
+		self.employee2 = frappe.get_doc(
+			{
+				"doctype": "Employee",
+				"first_name": "Test Default Shift",
+				"employee": "EMP002",
+				"date_of_birth": "1992-01-01",
+				"date_of_joining": "2023-01-01",
+				"default_shift": self.shift.name,
+				"gender": "Male",
+				"company": "_Test Company",
+			}
+		).insert()
 
-        self.employee3 = frappe.get_doc(
-            {
-                "doctype": "Employee",
-                "first_name": "Test Not Assigned",
-                "employee": "EMP003",
-                "date_of_birth": "1992-01-01",
-                "date_of_joining": "2023-01-01",
-                "default_shift": "",
-                "gender": "Male",
-            }
-        ).insert()
+		self.employee3 = frappe.get_doc(
+			{
+				"doctype": "Employee",
+				"first_name": "Test Not Assigned",
+				"employee": "EMP003",
+				"date_of_birth": "1992-01-01",
+				"date_of_joining": "2023-01-01",
+				"default_shift": "",
+				"gender": "Male",
+				"company": "_Test Company",
+			}
+		).insert()
 
-        # Assign a shift to employee1 via Shift Assignment
-        self.shift_assignment = frappe.get_doc(
-            {
-                "doctype": "Shift Assignment",
-                "employee": self.employee1.name,
-                "shift_type": self.shift.name,
-                "start_date": frappe.utils.getdate("2023-02-28"),
-                "end_date": frappe.utils.getdate("2023-03-10"),
-            }
-        ).insert()
-        # Prepare the unmarked_attendance sample input
-        unmarked_attendance = [
-            {"employee": self.employee1.name},
-            {"employee": self.employee2.name},
-            {"employee": self.employee3.name},
-        ]
+		# Assign a shift to employee1 via Shift Assignment
+		self.shift_assignment = frappe.get_doc(
+			{
+				"doctype": "Shift Assignment",
+				"employee": self.employee1.name,
+				"shift_type": self.shift.name,
+				"start_date": frappe.utils.getdate("2023-02-28"),
+				"end_date": frappe.utils.getdate("2023-03-10"),
+			}
+		).insert()
+		# Prepare the unmarked_attendance sample input
+		unmarked_attendance = [
+			{"employee": self.employee1.name},
+			{"employee": self.employee2.name},
+			{"employee": self.employee3.name},
+		]
 
-        shift = self.shift.name
-        date = "2023-03-01"
+		shift = self.shift.name
+		date = "2023-03-01"
 
-        result = _get_unmarked_attendance_with_shift(unmarked_attendance, shift, date)
+		result = _get_unmarked_attendance_with_shift(unmarked_attendance, shift, date)
 
-        # Only employee1 and employee2 have the shift (assigned/default)
-        filtered = set([emp["employee"] for emp in result])
-        self.assertIn(self.employee1.name, filtered)
-        self.assertIn(self.employee2.name, filtered)
-        self.assertNotIn(self.employee3.name, filtered)
+		# Only employee1 and employee2 have the shift (assigned/default)
+		filtered = set([emp["employee"] for emp in result])
+		self.assertIn(self.employee1.name, filtered)
+		self.assertIn(self.employee2.name, filtered)
+		self.assertNotIn(self.employee3.name, filtered)
+
+	def test_mark_half_day_attendance_permissions(self):
+		user_no_role = "test_no_role@example.com"
+
+		frappe.set_user("Administrator")
+		make_employee(user_no_role, company="_Test Company")
+
+		date = add_days(getdate(), -1)
+		while is_holiday(employee=self.employee1, date=date):
+			date = add_days(date, -1)
+
+		# Create and submit an attendance record as Administrator
+		attendance = frappe.get_doc(
+			{
+				"doctype": "Attendance",
+				"employee": self.employee1,
+				"attendance_date": date,
+				"status": "Present",
+			}
+		).insert()
+		attendance.submit()
+
+		# Scenario 1 (Security): user without Attendance write permission
+		# Verify the unauthorized user cannot update half-day attendance
+		frappe.set_user(user_no_role)
+		try:
+			# Precondition: verify the user lacks doctype-level write access
+			self.assertFalse(frappe.has_permission("Attendance", "write"))
+
+			with self.assertRaises(frappe.PermissionError):
+				mark_employee_attendance(
+					employee_list=[],
+					status="Present",
+					date=date,
+					mark_half_day=True,
+					half_day_status="Absent",
+					half_day_employee_list=[self.employee1],
+				)
+		finally:
+			frappe.set_user("Administrator")
+
+		# Verify the record was NOT modified
+		attendance.reload()
+		self.assertIsNone(attendance.half_day_status)
+		self.assertEqual(attendance.status, "Present")
+
+		# Scenario 2 (Positive): Administrator can update half-day attendance
+		mark_employee_attendance(
+			employee_list=[],
+			status="Present",
+			date=date,
+			mark_half_day=True,
+			half_day_status="Absent",
+			half_day_employee_list=[self.employee1],
+		)
+
+		attendance.reload()
+		self.assertEqual(attendance.half_day_status, "Absent")
+		self.assertEqual(attendance.status, "Present")
 
 
-def create_leave_allocation(employee, leave_type):
-    frappe.get_doc(
-        {
-            "doctype": "Leave Allocation",
-            "employee": employee.name,
-            "employee_name": employee.employee_name,
-            "leave_type": leave_type.name,
-            "from_date": add_days(getdate(), -2),
-            "new_leaves_allocated": 15,
-            "carry_forward": 0,
-            "to_date": add_days(getdate(), 30),
-        }
-    ).submit()
+def create_leave_allocation(employee, leave_type, date=None):
+	from_date = add_days(date or getdate(), -2)
+	frappe.get_doc(
+		{
+			"doctype": "Leave Allocation",
+			"employee": employee.name,
+			"employee_name": employee.employee_name,
+			"leave_type": leave_type.name,
+			"from_date": from_date,
+			"new_leaves_allocated": 15,
+			"carry_forward": 0,
+			"to_date": add_days(getdate(), 30),
+		}
+	).submit()

--- a/hrms/hr/doctype/employee_checkin/employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.py
@@ -2,208 +2,220 @@
 # For license information, please see license.txt
 
 
+from datetime import date, datetime, timedelta
+
 import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import cint, get_datetime
 
-from hrms.hr.doctype.shift_assignment.shift_assignment import (
-    get_actual_start_end_datetime_of_shift,
-)
+from hrms.hr.doctype.shift_assignment.shift_assignment import get_actual_start_end_datetime_of_shift
 from hrms.hr.utils import (
-    get_distance_between_coordinates,
-    set_geolocation_from_coordinates,
-    validate_active_employee,
+	get_distance_between_coordinates,
+	set_geolocation_from_coordinates,
+	validate_active_employee,
 )
 
 
 class CheckinRadiusExceededError(frappe.ValidationError):
-    pass
+	pass
 
 
 class EmployeeCheckin(Document):
-    def before_validate(self):
-        self.time = get_datetime(self.time).replace(microsecond=0)
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
 
-    def validate(self):
-        validate_active_employee(self.employee)
-        self.validate_duplicate_log()
-        self.validate_time_change()
-        self.fetch_shift()
-        self.set_geolocation()
-        self.validate_distance_from_shift_location()
+	from typing import TYPE_CHECKING
 
-    def validate_duplicate_log(self):
-        doc = frappe.db.exists(
-            "Employee Checkin",
-            {
-                "employee": self.employee,
-                "time": self.time,
-                "name": ("!=", self.name),
-                "log_type": self.log_type,
-            },
-        )
-        if doc:
-            doc_link = frappe.get_desk_link("Employee Checkin", doc)
-            frappe.throw(
-                _("This employee already has a log with the same timestamp.{0}").format(
-                    "<Br>" + doc_link
-                )
-            )
+	if TYPE_CHECKING:
+		from frappe.types import DF
 
-    def validate_time_change(self):
-        if self.attendance and self.has_value_changed("time"):
-            frappe.throw(
-                title=_("Cannot Modify Time"),
-                msg=_(
-                    "An attendance record is linked to this checkin. Please cancel the attendance before modifying time."
-                ),
-            )
+		attendance: DF.Link | None
+		device_id: DF.Data | None
+		employee: DF.Link
+		employee_name: DF.Data | None
+		latitude: DF.Float
+		log_type: DF.Literal["", "IN", "OUT"]
+		longitude: DF.Float
+		offshift: DF.Check
+		overtime_type: DF.Link | None
+		shift: DF.Link | None
+		shift_actual_end: DF.Datetime | None
+		shift_actual_start: DF.Datetime | None
+		shift_end: DF.Datetime | None
+		shift_start: DF.Datetime | None
+		skip_auto_attendance: DF.Check
+		time: DF.Datetime
+	# end: auto-generated types
 
-    @frappe.whitelist()
-    def set_geolocation(self):
-        set_geolocation_from_coordinates(self)
+	def before_validate(self):
+		self.time = get_datetime(self.time).replace(microsecond=0)
 
-    @frappe.whitelist()
-    def fetch_shift(self):
-        if not (
-            shift_actual_timings := get_actual_start_end_datetime_of_shift(
-                self.employee, get_datetime(self.time), True
-            )
-        ):
-            self.shift = None
-            self.offshift = 1
-            return
+	def validate(self):
+		validate_active_employee(self.employee)
+		self.validate_duplicate_log()
+		self.validate_time_change()
+		self.fetch_shift()
+		self.set_geolocation()
+		self.validate_distance_from_shift_location()
 
-        if (
-            shift_actual_timings.shift_type.determine_check_in_and_check_out
-            == "Strictly based on Log Type in Employee Checkin"
-            and not self.log_type
-            and not self.skip_auto_attendance
-        ):
-            frappe.throw(
-                _(
-                    "Log Type is required for check-ins falling in the shift: {0}."
-                ).format(shift_actual_timings.shift_type.name)
-            )
-        if not self.attendance:
-            self.offshift = 0
-            self.shift = shift_actual_timings.shift_type.name
-            self.shift_actual_start = shift_actual_timings.actual_start
-            self.shift_actual_end = shift_actual_timings.actual_end
-            self.shift_start = shift_actual_timings.start_datetime
-            self.shift_end = shift_actual_timings.end_datetime
+	def validate_duplicate_log(self):
+		doc = frappe.db.exists(
+			"Employee Checkin",
+			{
+				"employee": self.employee,
+				"time": self.time,
+				"name": ("!=", self.name),
+				"log_type": self.log_type,
+			},
+		)
+		if doc:
+			doc_link = frappe.get_desk_link("Employee Checkin", doc)
+			frappe.throw(
+				_("This employee already has a log with the same timestamp.{0}").format("<Br>" + doc_link)
+			)
 
-    def validate_distance_from_shift_location(self):
-        if not frappe.db.get_single_value("HR Settings", "allow_geolocation_tracking"):
-            return
+	def validate_time_change(self):
+		if self.attendance and self.has_value_changed("time"):
+			frappe.throw(
+				title=_("Cannot Modify Time"),
+				msg=_(
+					"An attendance record is linked to this checkin. Please cancel the attendance before modifying time."
+				),
+			)
 
-        if not (self.latitude or self.longitude):
-            frappe.throw(
-                _("Latitude and longitude values are required for checking in.")
-            )
+	@frappe.whitelist()
+	def set_geolocation(self):
+		set_geolocation_from_coordinates(self)
 
-        assignment_locations = frappe.get_all(
-            "Shift Assignment",
-            filters={
-                "employee": self.employee,
-                "shift_type": self.shift,
-                "start_date": ["<=", self.time],
-                "shift_location": ["is", "set"],
-                "docstatus": 1,
-                "status": "Active",
-            },
-            or_filters=[["end_date", ">=", self.time], ["end_date", "is", "not set"]],
-            pluck="shift_location",
-        )
-        if not assignment_locations:
-            return
+	@frappe.whitelist()
+	def fetch_shift(self):
+		if not (
+			shift_actual_timings := get_actual_start_end_datetime_of_shift(
+				self.employee, get_datetime(self.time), True
+			)
+		):
+			self.shift = None
+			self.offshift = 1
+			return
 
-        checkin_radius, latitude, longitude = frappe.db.get_value(
-            "Shift Location",
-            assignment_locations[0],
-            ["checkin_radius", "latitude", "longitude"],
-        )
-        if checkin_radius <= 0:
-            return
+		if (
+			shift_actual_timings.shift_type.determine_check_in_and_check_out
+			== "Strictly based on Log Type in Employee Checkin"
+			and not self.log_type
+			and not self.skip_auto_attendance
+		):
+			frappe.throw(
+				_("Log Type is required for check-ins falling in the shift: {0}.").format(
+					shift_actual_timings.shift_type.name
+				)
+			)
+		if not self.attendance:
+			self.offshift = 0
+			self.shift = shift_actual_timings.shift_type.name
+			self.shift_actual_start = shift_actual_timings.actual_start
+			self.shift_actual_end = shift_actual_timings.actual_end
+			self.shift_start = shift_actual_timings.start_datetime
+			self.shift_end = shift_actual_timings.end_datetime
+			self.overtime_type = shift_actual_timings.overtime_type or None
 
-        distance = get_distance_between_coordinates(
-            latitude, longitude, self.latitude, self.longitude
-        )
-        if distance > checkin_radius:
-            frappe.throw(
-                _(
-                    "You must be within {0} meters of your shift location to check in."
-                ).format(checkin_radius),
-                exc=CheckinRadiusExceededError,
-            )
+	def validate_distance_from_shift_location(self):
+		if not frappe.db.get_single_value("HR Settings", "allow_geolocation_tracking"):
+			return
+
+		if not (self.latitude or self.longitude):
+			frappe.throw(_("Latitude and longitude values are required for checking in."))
+
+		assignment_locations = frappe.get_all(
+			"Shift Assignment",
+			filters={
+				"employee": self.employee,
+				"shift_type": self.shift,
+				"start_date": ["<=", self.time],
+				"shift_location": ["is", "set"],
+				"docstatus": 1,
+				"status": "Active",
+			},
+			or_filters=[["end_date", ">=", self.time], ["end_date", "is", "not set"]],
+			pluck="shift_location",
+		)
+		if not assignment_locations:
+			return
+
+		checkin_radius, latitude, longitude = frappe.db.get_value(
+			"Shift Location", assignment_locations[0], ["checkin_radius", "latitude", "longitude"]
+		)
+		if checkin_radius <= 0:
+			return
+
+		distance = get_distance_between_coordinates(latitude, longitude, self.latitude, self.longitude)
+		if distance > checkin_radius:
+			frappe.throw(
+				_("You must be within {0} meters of your shift location to check in.").format(checkin_radius),
+				exc=CheckinRadiusExceededError,
+			)
 
 
 @frappe.whitelist()
 def add_log_based_on_employee_field(
-    employee_field_value,
-    timestamp,
-    device_id=None,
-    log_type=None,
-    skip_auto_attendance=0,
-    employee_fieldname="attendance_device_id",
-    latitude=None,
-    longitude=None,
-):
-    """Finds the relevant Employee using the employee field value and creates a Employee Checkin.
+	employee_field_value: str | int,
+	timestamp: str | datetime,
+	device_id: str | int | None = None,
+	log_type: str | None = None,
+	skip_auto_attendance: str | bool | int = 0,
+	employee_fieldname: str = "attendance_device_id",
+	latitude: str | float | None = None,
+	longitude: str | float | None = None,
+) -> Document:
+	"""Finds the relevant Employee using the employee field value and creates a Employee Checkin.
 
-    :param employee_field_value: The value to look for in employee field.
-    :param timestamp: The timestamp of the Log. Currently expected in the following format as string: '2019-05-08 10:48:08.000000'
-    :param device_id: (optional)Location / Device ID. A short string is expected.
-    :param log_type: (optional)Direction of the Punch if available (IN/OUT).
-    :param skip_auto_attendance: (optional)Skip auto attendance field will be set for this log(0/1).
-    :param employee_fieldname: (Default: attendance_device_id)Name of the field in Employee DocType based on which employee lookup will happen.
-    :latitude: (optional) Latitude of the shift location.
-    :longitude: (optional) Longitude of the shift location.
-    """
+	:param employee_field_value: The value to look for in employee field.
+	:param timestamp: The timestamp of the Log. Currently expected in the following format as string: '2019-05-08 10:48:08.000000'
+	:param device_id: (optional)Location / Device ID. A short string is expected.
+	:param log_type: (optional)Direction of the Punch if available (IN/OUT).
+	:param skip_auto_attendance: (optional)Skip auto attendance field will be set for this log(0/1).
+	:param employee_fieldname: (Default: attendance_device_id)Name of the field in Employee DocType based on which employee lookup will happen.
+	:latitude: (optional) Latitude of the shift location.
+	:longitude: (optional) Longitude of the shift location.
+	"""
 
-    if not employee_field_value or not timestamp:
-        frappe.throw(_("'employee_field_value' and 'timestamp' are required."))
+	if not employee_field_value or not timestamp:
+		frappe.throw(_("'employee_field_value' and 'timestamp' are required."))
 
-    employee = frappe.db.get_values(
-        "Employee",
-        {employee_fieldname: employee_field_value},
-        ["name", "employee_name", employee_fieldname],
-        as_dict=True,
-    )
-    if employee:
-        employee = employee[0]
-    else:
-        frappe.throw(
-            _("No Employee found for the given employee field value. '{}': {}").format(
-                employee_fieldname, employee_field_value
-            )
-        )
+	allowed_employee_fieldnames = {"name", "employee", "attendance_device_id"}
+	if employee_fieldname not in allowed_employee_fieldnames:
+		frappe.throw(
+			_("'employee_fieldname' must be one of {0}.").format(", ".join(allowed_employee_fieldnames))
+		)
 
-    doc = frappe.new_doc("Employee Checkin")
-    doc.employee = employee.name
-    doc.employee_name = employee.employee_name
-    doc.time = timestamp
-    doc.device_id = device_id
-    doc.log_type = log_type
-    doc.latitude = latitude
-    doc.longitude = longitude
-    if cint(skip_auto_attendance) == 1:
-        doc.skip_auto_attendance = "1"
-    doc.insert()
+	employee = frappe.db.get_values(
+		"Employee",
+		{employee_fieldname: employee_field_value},
+		["name", "employee_name", employee_fieldname],
+		as_dict=True,
+	)
+	if employee:
+		employee = employee[0]
+	else:
+		frappe.throw(
+			_("No Employee found for the given employee field value. '{}': {}").format(
+				employee_fieldname, employee_field_value
+			)
+		)
 
-    return doc
+	doc = frappe.new_doc("Employee Checkin")
+	doc.employee = employee.name
+	doc.employee_name = employee.employee_name
+	doc.time = timestamp
+	doc.device_id = device_id
+	doc.log_type = log_type
+	doc.latitude = latitude
+	doc.longitude = longitude
+	if cint(skip_auto_attendance) == 1:
+		doc.skip_auto_attendance = "1"
+	doc.insert()
 
-
-@frappe.whitelist()
-def bulk_fetch_shift(checkins: list[str] | str) -> None:
-    if isinstance(checkins, str):
-        checkins = frappe.json.loads(checkins)
-    for d in checkins:
-        doc = frappe.get_doc("Employee Checkin", d)
-        doc.fetch_shift()
-        doc.flags.ignore_validate = True
-        doc.save()
+	return doc
 
 
 @frappe.whitelist()
@@ -218,218 +230,285 @@ def bulk_fetch_shift(checkins: list[str] | str) -> None:
 
 
 def mark_attendance_and_link_log(
-    logs,
-    attendance_status,
-    attendance_date,
-    working_hours=None,
-    late_entry=False,
-    early_exit=False,
-    in_time=None,
-    out_time=None,
-    shift=None,
+	logs: list[Document],
+	attendance_status: str,
+	attendance_date: str | date,
+	working_hours: float | None = None,
+	late_entry: int | bool = False,
+	early_exit: int | bool = False,
+	in_time: datetime | None = None,
+	out_time: datetime | None = None,
+	shift: str | None = None,
+	overtime_type: str | None = None,
+) -> Document | None:
+	"""Creates an attendance and links the attendance to the Employee Checkin.
+	Note: If attendance is already present for the given date, the logs are marked as skipped and no exception is thrown.
+
+	:param logs: The List of 'Employee Checkin'.
+	:param attendance_status: Attendance status to be marked. One of: (Present, Absent, Half Day, Skip). Note: 'On Leave' is not supported by this function.
+	:param attendance_date: Date of the attendance to be created.
+	:param working_hours: (optional)Number of working hours for the given date.
+	"""
+	log_names = [x.name for x in logs]
+	employee = logs[0].employee
+
+	if attendance_status == "Skip":
+		skip_attendance_in_checkins(log_names)
+		return None
+
+	if attendance_status not in ("Present", "Absent", "Half Day"):
+		frappe.throw(_("{0} is an invalid Attendance Status.").format(attendance_status))
+
+	try:
+		frappe.db.savepoint("attendance_creation")
+
+		attendance = create_or_update_attendance(
+			employee=employee,
+			attendance_date=attendance_date,
+			attendance_status=attendance_status,
+			working_hours=working_hours,
+			shift=shift,
+			late_entry=late_entry,
+			early_exit=early_exit,
+			in_time=in_time,
+			out_time=out_time,
+			overtime_type=overtime_type,
+		)
+
+		if attendance_status == "Absent":
+			attendance.add_comment(
+				text=_("Employee was marked Absent for not meeting the working hours threshold.")
+			)
+
+		update_attendance_in_checkins(log_names, attendance.name)
+		return attendance
+
+	except frappe.ValidationError as e:
+		handle_attendance_exception(log_names, e)
+		return None
+
+
+def create_or_update_attendance(
+	employee,
+	attendance_date,
+	attendance_status,
+	working_hours=None,
+	shift=None,
+	late_entry=False,
+	early_exit=False,
+	in_time=None,
+	out_time=None,
+	overtime_type=None,
 ):
-    """Creates an attendance and links the attendance to the Employee Checkin.
-    Note: If attendance is already present for the given date, the logs are marked as skipped and no exception is thrown.
+	"""Creates a new attendance or updates an existing half-day attendance."""
+	if attendance := get_existing_half_day_attendance(employee, attendance_date):
+		frappe.db.set_value(
+			"Attendance",
+			attendance.name,
+			{
+				"working_hours": working_hours,
+				"shift": shift,
+				"late_entry": late_entry,
+				"early_exit": early_exit,
+				"in_time": in_time,
+				"out_time": out_time,
+				"half_day_status": "Absent" if attendance_status == "Absent" else "Present",
+				"modify_half_day_status": 0,
+			},
+		)
+		return frappe.get_doc("Attendance", attendance.name)
+	else:
+		attendance = frappe.new_doc("Attendance")
+		attendance.update(
+			{
+				"doctype": "Attendance",
+				"employee": employee,
+				"attendance_date": attendance_date,
+				"status": attendance_status,
+				"working_hours": working_hours,
+				"shift": shift,
+				"late_entry": late_entry,
+				"early_exit": early_exit,
+				"in_time": in_time,
+				"out_time": out_time,
+			}
+		)
 
-    :param logs: The List of 'Employee Checkin'.
-    :param attendance_status: Attendance status to be marked. One of: (Present, Absent, Half Day, Skip). Note: 'On Leave' is not supported by this function.
-    :param attendance_date: Date of the attendance to be created.
-    :param working_hours: (optional)Number of working hours for the given date.
-    """
-    log_names = [x.name for x in logs]
-    employee = logs[0].employee
+		# Set overtime data if applicable
+		if overtime_type and attendance_status == "Present":
+			overtime_data = get_overtime_data(shift, working_hours)
+			if overtime_data:
+				attendance.update(
+					{
+						"overtime_type": overtime_type,
+						"standard_working_hours": overtime_data.get("standard_working_hours"),
+						"actual_overtime_duration": overtime_data.get("actual_overtime_duration"),
+					}
+				)
+		attendance.save()
+		attendance.submit()
 
-    if attendance_status == "Skip":
-        skip_attendance_in_checkins(log_names)
-        return None
+	return attendance
 
-    elif attendance_status in ("Present", "Absent", "Half Day"):
-        try:
-            frappe.db.savepoint("attendance_creation")
-            if attendance := get_existing_half_day_attendance(
-                employee, attendance_date
-            ):
-                frappe.db.set_value(
-                    "Attendance",
-                    attendance.name,
-                    {
-                        "working_hours": working_hours,
-                        "shift": shift,
-                        "late_entry": late_entry,
-                        "early_exit": early_exit,
-                        "in_time": in_time,
-                        "out_time": out_time,
-                        "half_day_status": (
-                            "Absent" if attendance_status == "Absent" else "Present"
-                        ),
-                        "modify_half_day_status": 0,
-                    },
-                )
-            else:
-                attendance = frappe.new_doc("Attendance")
-                attendance.update(
-                    {
-                        "doctype": "Attendance",
-                        "employee": employee,
-                        "attendance_date": attendance_date,
-                        "status": attendance_status,
-                        "working_hours": working_hours,
-                        "shift": shift,
-                        "late_entry": late_entry,
-                        "early_exit": early_exit,
-                        "in_time": in_time,
-                        "out_time": out_time,
-                        "half_day_status": (
-                            "Absent" if attendance_status == "Half Day" else None
-                        ),
-                    }
-                ).submit()
 
-            if attendance_status == "Absent":
-                attendance.add_comment(
-                    text=_(
-                        "Employee was marked Absent for not meeting the working hours threshold."
-                    )
-                )
+def get_overtime_data(shift_name, working_hours):
+	overtime_data = {}
 
-            update_attendance_in_checkins(log_names, attendance.name)
-            return attendance
+	shift_type_details = frappe.db.get_value(
+		doctype="Shift Type",
+		filters={"name": shift_name},
+		fieldname=["allow_overtime", "start_time", "end_time"],
+		as_dict=True,
+	)
 
-        except frappe.ValidationError as e:
-            handle_attendance_exception(log_names, e)
+	if not shift_type_details or not shift_type_details.allow_overtime:
+		return overtime_data
 
-    else:
-        frappe.throw(_("{} is an invalid Attendance Status.").format(attendance_status))
+	standard_working_hours = calculate_time_difference(
+		shift_type_details.start_time, shift_type_details.end_time
+	)
+
+	if working_hours > standard_working_hours:
+		actual_overtime_duration = working_hours - standard_working_hours
+		overtime_data = {
+			"standard_working_hours": standard_working_hours,
+			"actual_overtime_duration": actual_overtime_duration,
+		}
+
+	return overtime_data
 
 
 def get_existing_half_day_attendance(employee, attendance_date):
-    attendance_name = frappe.db.exists(
-        "Attendance",
-        {
-            "employee": employee,
-            "attendance_date": attendance_date,
-            "status": "Half Day",
-            "modify_half_day_status": 1,
-            "leave_type": ("is", "set"),
-        },
-    )
+	attendance_name = frappe.db.exists(
+		"Attendance",
+		{
+			"employee": employee,
+			"attendance_date": attendance_date,
+			"status": "Half Day",
+			"modify_half_day_status": 1,
+			"leave_type": ("is", "set"),
+		},
+	)
 
-    if attendance_name:
-        attendance_doc = frappe.get_doc("Attendance", attendance_name)
-        return attendance_doc
-    return None
+	if attendance_name:
+		attendance_doc = frappe.get_doc("Attendance", attendance_name)
+		return attendance_doc
+	return None
 
 
 def calculate_working_hours(logs, check_in_out_type, working_hours_calc_type):
-    """Given a set of logs in chronological order calculates the total working hours based on the parameters.
-    Zero is returned for all invalid cases.
+	"""Given a set of logs in chronological order calculates the total working hours based on the parameters.
+	Zero is returned for all invalid cases.
 
-    :param logs: The List of 'Employee Checkin'.
-    :param check_in_out_type: One of: 'Alternating entries as IN and OUT during the same shift', 'Strictly based on Log Type in Employee Checkin'
-    :param working_hours_calc_type: One of: 'First Check-in and Last Check-out', 'Every Valid Check-in and Check-out'
-    """
-    total_hours = 0
-    in_time = out_time = None
-    if check_in_out_type == "Alternating entries as IN and OUT during the same shift":
-        in_time = logs[0].time
-        if len(logs) >= 2:
-            out_time = logs[-1].time
-        if working_hours_calc_type == "First Check-in and Last Check-out":
-            # assumption in this case: First log always taken as IN, Last log always taken as OUT
-            total_hours = time_diff_in_hours(in_time, logs[-1].time)
-        elif working_hours_calc_type == "Every Valid Check-in and Check-out":
-            logs = logs[:]
-            while len(logs) >= 2:
-                total_hours += time_diff_in_hours(logs[0].time, logs[1].time)
-                del logs[:2]
+	:param logs: The List of 'Employee Checkin'.
+	:param check_in_out_type: One of: 'Alternating entries as IN and OUT during the same shift', 'Strictly based on Log Type in Employee Checkin'
+	:param working_hours_calc_type: One of: 'First Check-in and Last Check-out', 'Every Valid Check-in and Check-out'
+	"""
+	total_hours = 0
+	in_time = out_time = None
+	if check_in_out_type == "Alternating entries as IN and OUT during the same shift":
+		in_time = logs[0].time
+		if len(logs) >= 2:
+			out_time = logs[-1].time
+		if working_hours_calc_type == "First Check-in and Last Check-out":
+			# assumption in this case: First log always taken as IN, Last log always taken as OUT
+			total_hours = time_diff_in_hours(in_time, logs[-1].time)
+		elif working_hours_calc_type == "Every Valid Check-in and Check-out":
+			logs = logs[:]
+			while len(logs) >= 2:
+				total_hours += time_diff_in_hours(logs[0].time, logs[1].time)
+				del logs[:2]
 
-    elif check_in_out_type == "Strictly based on Log Type in Employee Checkin":
-        if working_hours_calc_type == "First Check-in and Last Check-out":
-            first_in_log_index = find_index_in_dict(logs, "log_type", "IN")
-            first_in_log = (
-                logs[first_in_log_index]
-                if first_in_log_index or first_in_log_index == 0
-                else None
-            )
-            last_out_log_index = find_index_in_dict(reversed(logs), "log_type", "OUT")
-            last_out_log = (
-                logs[len(logs) - 1 - last_out_log_index]
-                if last_out_log_index or last_out_log_index == 0
-                else None
-            )
-            in_time = getattr(first_in_log, "time", None)
-            out_time = getattr(last_out_log, "time", None)
-            if first_in_log and last_out_log:
-                total_hours = time_diff_in_hours(in_time, out_time)
-        elif working_hours_calc_type == "Every Valid Check-in and Check-out":
-            in_log = out_log = None
-            for log in logs:
-                if in_log and out_log:
-                    if not in_time:
-                        in_time = in_log.time
-                    out_time = out_log.time
-                    total_hours += time_diff_in_hours(in_log.time, out_log.time)
-                    in_log = out_log = None
-                if not in_log:
-                    in_log = log if log.log_type == "IN" else None
-                    if in_log and not in_time:
-                        in_time = in_log.time
-                elif not out_log:
-                    out_log = log if log.log_type == "OUT" else None
+	elif check_in_out_type == "Strictly based on Log Type in Employee Checkin":
+		if working_hours_calc_type == "First Check-in and Last Check-out":
+			first_in_log_index = find_index_in_dict(logs, "log_type", "IN")
+			first_in_log = logs[first_in_log_index] if first_in_log_index or first_in_log_index == 0 else None
+			last_out_log_index = find_index_in_dict(reversed(logs), "log_type", "OUT")
+			last_out_log = (
+				logs[len(logs) - 1 - last_out_log_index]
+				if last_out_log_index or last_out_log_index == 0
+				else None
+			)
+			in_time = getattr(first_in_log, "time", None)
+			out_time = getattr(last_out_log, "time", None)
+			if first_in_log and last_out_log:
+				total_hours = time_diff_in_hours(in_time, out_time)
+		elif working_hours_calc_type == "Every Valid Check-in and Check-out":
+			in_log = out_log = None
+			for log in logs:
+				if in_log and out_log:
+					if not in_time:
+						in_time = in_log.time
+					out_time = out_log.time
+					total_hours += time_diff_in_hours(in_log.time, out_log.time)
+					in_log = out_log = None
+				if not in_log:
+					in_log = log if log.log_type == "IN" else None
+					if in_log and not in_time:
+						in_time = in_log.time
+				elif not out_log:
+					out_log = log if log.log_type == "OUT" else None
 
-            if in_log and out_log:
-                out_time = out_log.time
-                total_hours += time_diff_in_hours(in_log.time, out_log.time)
+			if in_log and out_log:
+				out_time = out_log.time
+				total_hours += time_diff_in_hours(in_log.time, out_log.time)
 
-    return total_hours, in_time, out_time
+	return total_hours, in_time, out_time
 
 
 def time_diff_in_hours(start, end):
-    return round(float((end - start).total_seconds()) / 3600, 2)
+	return round(float((end - start).total_seconds()) / 3600, 2)
 
 
 def find_index_in_dict(dict_list, key, value):
-    return next((index for (index, d) in enumerate(dict_list) if d[key] == value), None)
+	return next((index for (index, d) in enumerate(dict_list) if d[key] == value), None)
 
 
 def handle_attendance_exception(log_names: list, error_message: str):
-    frappe.db.rollback(save_point="attendance_creation")
-    frappe.clear_messages()
-    skip_attendance_in_checkins(log_names)
-    add_comment_in_checkins(log_names, error_message)
+	frappe.db.rollback(save_point="attendance_creation")
+	frappe.clear_messages()
+	skip_attendance_in_checkins(log_names)
+	add_comment_in_checkins(log_names, error_message)
 
 
 def add_comment_in_checkins(log_names: list, error_message: str):
-    text = "{prefix}<br>{error_message}".format(
-        prefix=frappe.bold(_("Reason for skipping auto attendance:")),
-        error_message=error_message,
-    )
+	text = "{prefix}<br>{error_message}".format(
+		prefix=frappe.bold(_("Reason for skipping auto attendance:")), error_message=error_message
+	)
 
-    for name in log_names:
-        frappe.get_doc(
-            {
-                "doctype": "Comment",
-                "comment_type": "Comment",
-                "reference_doctype": "Employee Checkin",
-                "reference_name": name,
-                "content": text,
-            }
-        ).insert(ignore_permissions=True)
+	for name in log_names:
+		frappe.get_doc(
+			{
+				"doctype": "Comment",
+				"comment_type": "Comment",
+				"reference_doctype": "Employee Checkin",
+				"reference_name": name,
+				"content": text,
+			}
+		).insert(ignore_permissions=True)
 
 
 def skip_attendance_in_checkins(log_names: list):
-    EmployeeCheckin = frappe.qb.DocType("Employee Checkin")
-    (
-        frappe.qb.update(EmployeeCheckin)
-        .set("skip_auto_attendance", 1)
-        .where(EmployeeCheckin.name.isin(log_names))
-    ).run()
+	EmployeeCheckin = frappe.qb.DocType("Employee Checkin")
+	(
+		frappe.qb.update(EmployeeCheckin)
+		.set("skip_auto_attendance", 1)
+		.where(EmployeeCheckin.name.isin(log_names))
+	).run()
 
 
 def update_attendance_in_checkins(log_names: list, attendance_id: str):
-    EmployeeCheckin = frappe.qb.DocType("Employee Checkin")
-    (
-        frappe.qb.update(EmployeeCheckin)
-        .set("attendance", attendance_id)
-        .where(EmployeeCheckin.name.isin(log_names))
-    ).run()
+	EmployeeCheckin = frappe.qb.DocType("Employee Checkin")
+	(
+		frappe.qb.update(EmployeeCheckin)
+		.set("attendance", attendance_id)
+		.where(EmployeeCheckin.name.isin(log_names))
+	).run()
+
+
+def calculate_time_difference(start_time, end_time):
+	if end_time < start_time:
+		end_time += timedelta(days=1)
+	time_difference = abs(start_time - end_time)
+
+	return round(time_difference.total_seconds() / 3600, 2)

--- a/hrms/hr/doctype/employee_onboarding/employee_onboarding.py
+++ b/hrms/hr/doctype/employee_onboarding/employee_onboarding.py
@@ -4,6 +4,7 @@
 
 import frappe
 from frappe import _
+from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 
 from hrms.controllers.employee_boarding_controller import EmployeeBoardingController
@@ -14,6 +15,37 @@ class IncompleteTaskError(frappe.ValidationError):
 
 
 class EmployeeOnboarding(EmployeeBoardingController):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from hrms.hr.doctype.employee_boarding_activity.employee_boarding_activity import (
+			EmployeeBoardingActivity,
+		)
+
+		activities: DF.Table[EmployeeBoardingActivity]
+		amended_from: DF.Link | None
+		boarding_begins_on: DF.Date
+		boarding_status: DF.Literal["Pending", "In Process", "Completed"]
+		company: DF.Link
+		date_of_joining: DF.Date
+		department: DF.Link | None
+		designation: DF.Link | None
+		employee: DF.Link | None
+		employee_grade: DF.Link | None
+		employee_name: DF.Data
+		employee_onboarding_template: DF.Link | None
+		holiday_list: DF.Link | None
+		job_applicant: DF.Link
+		job_offer: DF.Link
+		notify_users_by_email: DF.Check
+		project: DF.Link | None
+	# end: auto-generated types
+
 	def validate(self):
 		super().validate()
 		self.set_employee()
@@ -60,6 +92,7 @@ class EmployeeOnboarding(EmployeeBoardingController):
 
 	@frappe.whitelist()
 	def mark_onboarding_as_completed(self):
+		self.check_permission("write")
 		for activity in self.activities:
 			frappe.db.set_value("Task", activity.task, "status", "Completed")
 		frappe.db.set_value("Project", self.project, "status", "Completed")
@@ -68,7 +101,7 @@ class EmployeeOnboarding(EmployeeBoardingController):
 
 
 @frappe.whitelist()
-def make_employee(source_name, target_doc=None):
+def make_employee(source_name: str, target_doc: str | Document | None = None) -> Document:
 	doc = frappe.get_doc("Employee Onboarding", source_name)
 	doc.validate_employee_creation()
 

--- a/hrms/hr/doctype/expense_claim_detail/expense_claim_detail.json
+++ b/hrms/hr/doctype/expense_claim_detail/expense_claim_detail.json
@@ -13,8 +13,10 @@
   "description",
   "amounts_sb",
   "amount",
+  "base_amount",
   "column_break_8",
   "sanctioned_amount",
+  "base_sanctioned_amount",
   "accounting_dimensions_section",
   "cost_center",
   "dimension_col_break",
@@ -58,8 +60,6 @@
    "read_only": 1
   },
   {
-   "fetch_from": "expense_type.description",
-   "fetch_if_empty": 1,
    "fieldname": "description",
    "fieldtype": "Text Editor",
    "in_list_view": 1,
@@ -74,9 +74,10 @@
    "fieldtype": "Currency",
    "in_list_view": 1,
    "label": "Amount",
+   "no_copy": 1,
    "oldfieldname": "claim_amount",
    "oldfieldtype": "Currency",
-   "options": "Company:company:default_currency",
+   "options": "currency",
    "print_width": "150px",
    "reqd": 1,
    "width": "150px"
@@ -92,7 +93,7 @@
    "label": "Sanctioned Amount",
    "oldfieldname": "sanctioned_amount",
    "oldfieldtype": "Currency",
-   "options": "Company:company:default_currency",
+   "options": "currency",
    "print_width": "150px",
    "width": "150px"
   },
@@ -126,17 +127,39 @@
   {
    "fieldname": "amounts_sb",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "base_amount",
+   "fieldtype": "Currency",
+   "label": "Amount (Company Currency)",
+   "oldfieldname": "claim_amount",
+   "oldfieldtype": "Currency",
+   "options": "Company:company:default_currency",
+   "print_width": "150px",
+   "width": "150px"
+  },
+  {
+   "fieldname": "base_sanctioned_amount",
+   "fieldtype": "Currency",
+   "label": "Sanctioned Amount (Company Currency)",
+   "oldfieldname": "sanctioned_amount",
+   "oldfieldtype": "Currency",
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "print_width": "150px",
+   "width": "150px"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-10-10 14:58:36.316268",
+ "modified": "2026-06-15 16:46:22.402968",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Expense Claim Detail",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []

--- a/hrms/hr/doctype/goal/goal.py
+++ b/hrms/hr/doctype/goal/goal.py
@@ -14,6 +14,33 @@ from hrms.hr.utils import validate_active_employee
 
 
 class Goal(NestedSet):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		appraisal_cycle: DF.Link | None
+		company: DF.Link | None
+		description: DF.TextEditor | None
+		employee: DF.Link
+		employee_name: DF.Data | None
+		end_date: DF.Date | None
+		goal_name: DF.Data
+		is_group: DF.Check
+		kra: DF.Link | None
+		lft: DF.Int
+		old_parent: DF.Link | None
+		parent_goal: DF.Link | None
+		progress: DF.Percent
+		rgt: DF.Int
+		start_date: DF.Date
+		status: DF.Literal["", "Pending", "In Progress", "Completed", "Archived", "Closed"]
+		user: DF.Data | None
+	# end: auto-generated types
+
 	nsm_parent_field = "parent_goal"
 
 	def before_insert(self):
@@ -136,48 +163,50 @@ class Goal(NestedSet):
 
 @frappe.whitelist()
 def get_children(doctype: str, parent: str, is_root: bool = False, **filters) -> list[dict]:
-	Goal = frappe.qb.DocType(doctype)
-
-	query = (
-		frappe.qb.from_(Goal)
-		.select(
-			Goal.name.as_("value"),
-			Goal.goal_name.as_("title"),
-			Goal.is_group.as_("expandable"),
-			Goal.status,
-			Goal.employee,
-			Goal.employee_name,
-			Goal.appraisal_cycle,
-			Goal.progress,
-			Goal.kra,
-		)
-		.where(Goal.status != "Archived")
-	)
+	query_filters = [["status", "!=", "Archived"]]
+	query_or_filters = []
 
 	if filters.get("employee"):
-		query = query.where(Goal.employee == filters.get("employee"))
+		query_filters.append(["employee", "=", filters.get("employee")])
 
 	if filters.get("appraisal_cycle"):
-		query = query.where(Goal.appraisal_cycle == filters.get("appraisal_cycle"))
+		query_filters.append(["appraisal_cycle", "=", filters.get("appraisal_cycle")])
 
 	if filters.get("goal"):
-		query = query.where(Goal.parent_goal == filters.get("goal"))
+		query_filters.append(["parent_goal", "=", filters.get("goal")])
+
 	elif parent and not is_root:
-		# via expand child
-		query = query.where(Goal.parent_goal == parent)
+		query_filters.append(["parent_goal", "=", parent])
+
 	else:
-		ifnull = CustomFunction("IFNULL", ["value", "default"])
-		query = query.where(ifnull(Goal.parent_goal, "") == "")
+		query_filters.append(["parent_goal", "in", ["", None]])
 
 	if filters.get("date_range"):
-		date_range = frappe.parse_json(filters.get("date_range"))
+		from_date, to_date = frappe.parse_json(filters.get("date_range"))
+		query_filters.append(["start_date", "between", [from_date, to_date]])
 
-		query = query.where(
-			(Goal.start_date.between(date_range[0], date_range[1]))
-			& ((Goal.end_date.isnull()) | (Goal.end_date.between(date_range[0], date_range[1])))
-		)
+		# or_filters
+		query_or_filters.append(["end_date", "is", "not set"])
+		query_or_filters.append(["end_date", "between", [from_date, to_date]])
 
-	goals = query.orderby(Goal.employee, Goal.kra).run(as_dict=True)
+	goals = frappe.get_list(
+		doctype,
+		fields=[
+			"name as value",
+			"goal_name as title",
+			"is_group as expandable",
+			"status",
+			"employee",
+			"employee_name",
+			"appraisal_cycle",
+			"progress",
+			"kra",
+		],
+		filters=query_filters,
+		or_filters=query_or_filters if query_or_filters else None,
+		order_by="employee, kra",
+	)
+
 	_update_goal_completion_status(goals)
 
 	return goals

--- a/hrms/hr/doctype/interview/interview.py
+++ b/hrms/hr/doctype/interview/interview.py
@@ -16,6 +16,33 @@ class DuplicateInterviewRoundError(frappe.ValidationError):
 
 
 class Interview(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from hrms.hr.doctype.interview_detail.interview_detail import InterviewDetail
+
+		amended_from: DF.Link | None
+		average_rating: DF.Rating
+		designation: DF.Link | None
+		expected_average_rating: DF.Rating
+		from_time: DF.Time
+		interview_details: DF.Table[InterviewDetail]
+		interview_summary: DF.Text | None
+		interview_type: DF.Link
+		job_applicant: DF.Link
+		job_opening: DF.Link | None
+		reminded: DF.Check
+		resume_link: DF.Data | None
+		scheduled_on: DF.Date
+		status: DF.Literal["Pending", "Under Review", "Cleared", "Rejected", "Cancelled"]
+		to_time: DF.Time
+	# end: auto-generated types
+
 	def validate(self):
 		self.validate_duplicate_interview()
 		self.validate_designation()
@@ -31,13 +58,13 @@ class Interview(Document):
 	def validate_duplicate_interview(self):
 		duplicate_interview = frappe.db.exists(
 			"Interview",
-			{"job_applicant": self.job_applicant, "interview_round": self.interview_round, "docstatus": 1},
+			{"job_applicant": self.job_applicant, "interview_type": self.interview_type, "docstatus": 1},
 		)
 
 		if duplicate_interview:
 			frappe.throw(
 				_(
-					"Job Applicants are not allowed to appear twice for the same Interview round. Interview {0} already scheduled for Job Applicant {1}"
+					"Job Applicants are not allowed to appear twice for the same Interview Type. Interview {0} already scheduled for Job Applicant {1}"
 				).format(
 					frappe.bold(get_link_to_form("Interview", duplicate_interview)),
 					frappe.bold(self.job_applicant),
@@ -50,8 +77,8 @@ class Interview(Document):
 			if self.designation != applicant_designation:
 				frappe.throw(
 					_(
-						"Interview Round {0} is only for Designation {1}. Job Applicant has applied for the role {2}"
-					).format(self.interview_round, frappe.bold(self.designation), applicant_designation),
+						"Interview Type {0} is only for Designation {1}. Job Applicant has applied for the role {2}"
+					).format(self.interview_type, frappe.bold(self.designation), applicant_designation),
 					exc=DuplicateInterviewRoundError,
 				)
 		else:
@@ -81,7 +108,9 @@ class Interview(Document):
 		return status_map.get(self.status, None)
 
 	@frappe.whitelist()
-	def reschedule_interview(self, scheduled_on, from_time, to_time):
+	def reschedule_interview(
+		self, scheduled_on: datetime.date, from_time: datetime.time, to_time: datetime.time
+	) -> None:
 		if scheduled_on == self.scheduled_on and from_time == self.from_time and to_time == self.to_time:
 			frappe.msgprint(
 				_("No changes found in timings."), indicator="orange", title=_("Interview Not Rescheduled")
@@ -121,10 +150,14 @@ class Interview(Document):
 
 		frappe.msgprint(_("Interview Rescheduled successfully"), indicator="green")
 
+	def on_discard(self):
+		self.db_set("status", "Cancelled")
+
 
 @frappe.whitelist()
-def get_interviewers(interview_round: str) -> list[str]:
-	return frappe.get_all("Interviewer", filters={"parent": interview_round}, fields=["user as interviewer"])
+def get_interviewers(interview_type: str) -> list[dict]:
+	frappe.has_permission("Interview Type", "read", interview_type, throw=True)
+	return frappe.get_all("Interviewer", filters={"parent": interview_type}, fields=["user as interviewer"])
 
 
 def get_recipients(name, for_feedback=0):
@@ -145,6 +178,8 @@ def get_recipients(name, for_feedback=0):
 
 @frappe.whitelist()
 def get_feedback(interview: str) -> list[dict]:
+	frappe.has_permission("Interview Feedback", "read", throw=True)
+
 	interview_feedback = frappe.qb.DocType("Interview Feedback")
 	employee = frappe.qb.DocType("Employee")
 
@@ -162,12 +197,13 @@ def get_feedback(interview: str) -> list[dict]:
 		.left_join(employee)
 		.on(interview_feedback.interviewer == employee.user_id)
 		.where((interview_feedback.interview == interview) & (interview_feedback.docstatus == 1))
-		.orderby(interview_feedback.modified)
+		.orderby(interview_feedback.creation)
 	).run(as_dict=True)
 
 
 @frappe.whitelist()
 def get_skill_wise_average_rating(interview: str) -> list[dict]:
+	frappe.has_permission("Interview", "read", interview, throw=True)
 	skill_assessment = frappe.qb.DocType("Skill Assessment")
 	interview_feedback = frappe.qb.DocType("Interview Feedback")
 	return (
@@ -185,27 +221,22 @@ def get_skill_wise_average_rating(interview: str) -> list[dict]:
 
 
 @frappe.whitelist()
-def update_job_applicant_status(args):
-	import json
-
+def update_job_applicant_status(status: str, job_applicant: str):
 	try:
-		if isinstance(args, str):
-			args = json.loads(args)
-
-		if not args.get("job_applicant"):
+		if not job_applicant:
 			frappe.throw(_("Please specify the job applicant to be updated."))
 
-		job_applicant = frappe.get_doc("Job Applicant", args["job_applicant"])
-		job_applicant.status = args["status"]
-		job_applicant.save()
+		doc = frappe.get_doc("Job Applicant", job_applicant)
+		doc.status = status
+		doc.save()
 
 		frappe.msgprint(
-			_("Updated the Job Applicant status to {0}").format(job_applicant.status),
+			_("Updated the Job Applicant status to {0}").format(doc.status),
 			alert=True,
 			indicator="green",
 		)
 	except Exception:
-		job_applicant.log_error("Failed to update Job Applicant status")
+		frappe.log_error("Failed to update Job Applicant status")
 		frappe.msgprint(
 			_("Failed to update the Job Applicant status"),
 			alert=True,
@@ -232,12 +263,12 @@ def send_interview_reminder():
 
 	interviews = frappe.get_all(
 		"Interview",
-		filters={
-			"scheduled_on": ["between", (datetime.datetime.now(), reminder_date_time)],
-			"status": "Pending",
-			"reminded": 0,
-			"docstatus": ["!=", 2],
-		},
+		filters=[
+			["scheduled_on", "between", [datetime.datetime.now(), reminder_date_time]],
+			["status", "=", "Pending"],
+			["reminded", "=", 0],
+			["docstatus", "!=", 2],
+		],
 	)
 
 	interview_template = frappe.get_doc("Email Template", reminder_settings.interview_reminder_template)
@@ -310,14 +341,15 @@ def send_daily_feedback_reminder():
 
 
 @frappe.whitelist()
-def get_expected_skill_set(interview_round):
+def get_expected_skill_set(interview_type: str):
+	frappe.has_permission("Interview Type", "read", interview_type, throw=True)
 	return frappe.get_all(
-		"Expected Skill Set", filters={"parent": interview_round}, fields=["skill"], order_by="idx"
+		"Expected Skill Set", filters={"parent": interview_type}, fields=["skill"], order_by="idx"
 	)
 
 
 @frappe.whitelist()
-def create_interview_feedback(data, interview_name, interviewer, job_applicant):
+def create_interview_feedback(data: str | dict, interview_name: str, interviewer: str, job_applicant: str):
 	import json
 
 	if isinstance(data, str):
@@ -350,7 +382,9 @@ def create_interview_feedback(data, interview_name, interviewer, job_applicant):
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
-def get_interviewer_list(doctype, txt, searchfield, start, page_len, filters):
+def get_interviewer_list(
+	doctype: str, txt: str, searchfield: str, start: int, page_len: int, filters: dict
+) -> list:
 	filters = [
 		["Has Role", "parent", "like", f"%{txt}%"],
 		["Has Role", "role", "=", "interviewer"],
@@ -371,7 +405,7 @@ def get_interviewer_list(doctype, txt, searchfield, start, page_len, filters):
 
 
 @frappe.whitelist()
-def get_events(start, end, filters=None):
+def get_events(start: str, end: str, filters: str | None = None):
 	"""Returns events for Gantt / Calendar view rendering.
 
 	:param start: Start date-time.
@@ -395,7 +429,7 @@ def get_events(start, end, filters=None):
 	interviews = frappe.db.sql(
 		f"""
 			SELECT DISTINCT
-				`tabInterview`.name, `tabInterview`.job_applicant, `tabInterview`.interview_round,
+				`tabInterview`.name, `tabInterview`.job_applicant, `tabInterview`.interview_type,
 				`tabInterview`.scheduled_on, `tabInterview`.status, `tabInterview`.from_time as from_time,
 				`tabInterview`.to_time as to_time
 			from
@@ -412,7 +446,7 @@ def get_events(start, end, filters=None):
 
 	for d in interviews:
 		subject_data = []
-		for field in ["name", "job_applicant", "interview_round"]:
+		for field in ["name", "job_applicant", "interview_type"]:
 			if not d.get(field):
 				continue
 			subject_data.append(d.get(field))

--- a/hrms/hr/doctype/interview_feedback/interview_feedback.py
+++ b/hrms/hr/doctype/interview_feedback/interview_feedback.py
@@ -10,6 +10,27 @@ from frappe.utils import flt, get_link_to_form, getdate
 
 
 class InterviewFeedback(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from hrms.hr.doctype.skill_assessment.skill_assessment import SkillAssessment
+
+		amended_from: DF.Link | None
+		average_rating: DF.Rating
+		feedback: DF.Text | None
+		interview: DF.Link
+		interview_type: DF.Link
+		interviewer: DF.Link
+		job_applicant: DF.Link | None
+		result: DF.Literal["", "Cleared", "Rejected"]
+		skill_assessment: DF.Table[SkillAssessment]
+	# end: auto-generated types
+
 	def validate(self):
 		self.validate_interviewer()
 		self.validate_interview_date()
@@ -81,4 +102,5 @@ class InterviewFeedback(Document):
 
 @frappe.whitelist()
 def get_applicable_interviewers(interview: str) -> list[str]:
+	frappe.has_permission("Interview", "read", interview, throw=True)
 	return frappe.get_all("Interview Detail", filters={"parent": interview}, pluck="interviewer")

--- a/hrms/hr/doctype/job_applicant/job_applicant.py
+++ b/hrms/hr/doctype/job_applicant/job_applicant.py
@@ -4,6 +4,8 @@
 # For license information, please see license.txt
 
 
+import json
+
 import frappe
 from frappe import _
 from frappe.model.document import Document
@@ -18,6 +20,34 @@ class DuplicationError(frappe.ValidationError):
 
 
 class JobApplicant(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		applicant_name: DF.Data
+		applicant_rating: DF.Rating
+		country: DF.Link | None
+		cover_letter: DF.Text | None
+		currency: DF.Link | None
+		designation: DF.Link | None
+		email_id: DF.Data
+		employee_referral: DF.Link | None
+		job_title: DF.Link | None
+		lower_range: DF.Currency
+		notes: DF.Data | None
+		phone_number: DF.Data | None
+		resume_attachment: DF.Attach | None
+		resume_link: DF.Data | None
+		source: DF.Link | None
+		source_name: DF.Link | None
+		status: DF.Literal["Open", "Replied", "Shortlisted", "Rejected", "Hold", "Accepted"]
+		upper_range: DF.Currency
+	# end: auto-generated types
+
 	def onload(self):
 		job_offer = frappe.get_all("Job Offer", filters={"job_applicant": self.name})
 		if job_offer:
@@ -49,6 +79,9 @@ class JobApplicant(Document):
 					_("Cannot create a Job Applicant against a closed Job Opening"), title=_("Not Allowed")
 				)
 
+		if frappe.flags.in_web_form and not self.source:
+			self.source = "Website Listing"
+
 	def set_status_for_employee_referral(self):
 		emp_ref = frappe.get_doc("Employee Referral", self.employee_referral)
 		if self.status in ["Open", "Replied", "Hold"]:
@@ -57,31 +90,52 @@ class JobApplicant(Document):
 			emp_ref.db_set("status", self.status)
 
 
+KANBAN_COLUMNS = ["Open", "Replied", "Shortlisted", "Accepted"]
+
+
 @frappe.whitelist()
-def create_interview(doc, interview_round):
-	import json
+def create_kanban_board(board_name: str) -> dict:
+	frappe.has_permission("Job Applicant", throw=True)
 
-	if isinstance(doc, str):
-		doc = json.loads(doc)
-		doc = frappe.get_doc(doc)
+	if frappe.db.exists("Kanban Board", board_name):
+		return frappe.get_doc("Kanban Board", board_name).as_dict()
 
-	round_designation = frappe.db.get_value("Interview Round", interview_round, "designation")
+	board = frappe.new_doc("Kanban Board")
+	board.kanban_board_name = board_name
+	board.reference_doctype = "Job Applicant"
+	board.field_name = "status"
+	board.private = 0
+	board.fields = json.dumps(["designation", "applicant_rating"])
+	board.show_labels = 1
+
+	for column_name in KANBAN_COLUMNS:
+		board.append("columns", {"column_name": column_name, "status": "Active"})
+
+	board.insert(ignore_permissions=True)
+	return board.as_dict()
+
+
+@frappe.whitelist()
+def create_interview(job_applicant: str, interview_type: str) -> Document:
+	doc = frappe.get_doc("Job Applicant", job_applicant)
+
+	round_designation = frappe.db.get_value("Interview Type", interview_type, "designation")
 
 	if round_designation and doc.designation and round_designation != doc.designation:
 		frappe.throw(
-			_("Interview Round {0} is only applicable for the Designation {1}").format(
-				interview_round, round_designation
+			_("Interview Type {0} is only applicable for the Designation {1}").format(
+				interview_type, round_designation
 			)
 		)
 
 	interview = frappe.new_doc("Interview")
-	interview.interview_round = interview_round
+	interview.interview_type = interview_type
 	interview.job_applicant = doc.name
 	interview.designation = doc.designation
 	interview.resume_link = doc.resume_link
 	interview.job_opening = doc.job_title
 
-	interviewers = get_interviewers(interview_round)
+	interviewers = get_interviewers(interview_type)
 	for d in interviewers:
 		interview.append("interview_details", {"interviewer": d.interviewer})
 
@@ -89,12 +143,60 @@ def create_interview(doc, interview_round):
 
 
 @frappe.whitelist()
-def get_interview_details(job_applicant):
+def schedule_interview(
+	job_applicant: str,
+	interview_type: str,
+	scheduled_on: str,
+	from_time: str | None = None,
+	to_time: str | None = None,
+	interviewers: str | list | None = None,
+) -> str:
+	frappe.has_permission("Interview", ptype="create", throw=True)
+	frappe.has_permission("Job Applicant", ptype="read", doc=job_applicant, throw=True)
+
+	applicant = frappe.get_doc("Job Applicant", job_applicant)
+
+	round_designation = frappe.db.get_value("Interview Type", interview_type, "designation")
+	if round_designation and applicant.designation and round_designation != applicant.designation:
+		frappe.throw(
+			_("Interview Type {0} is only applicable for Designation {1}").format(
+				frappe.bold(interview_type), frappe.bold(round_designation)
+			)
+		)
+
+	interview = frappe.new_doc("Interview")
+	interview.interview_type = interview_type
+	interview.job_applicant = applicant.name
+	interview.designation = applicant.designation
+	interview.resume_link = applicant.resume_link
+	interview.job_opening = applicant.job_title
+	interview.scheduled_on = scheduled_on
+	interview.from_time = from_time
+	interview.to_time = to_time
+
+	if isinstance(interviewers, str):
+		interviewers = json.loads(interviewers)
+
+	for entry in interviewers or []:
+		if entry.get("interviewer"):
+			interview.append("interview_details", {"interviewer": entry["interviewer"]})
+
+	interview.insert(ignore_permissions=True)
+
+	return interview.name
+
+
+@frappe.whitelist()
+def get_interview_details(job_applicant: str) -> dict:
+	frappe.has_permission("Job Applicant", "read", job_applicant, throw=True)
 	interview_details = frappe.db.get_all(
 		"Interview",
 		filters={"job_applicant": job_applicant, "docstatus": ["!=", 2]},
-		fields=["name", "interview_round", "scheduled_on", "average_rating", "status"],
+		fields=["name", "interview_type", "scheduled_on", "average_rating", "status"],
 	)
+	if not interview_details:
+		return None
+
 	interview_detail_map = {}
 	meta = frappe.get_meta("Interview")
 	number_of_stars = meta.get_options("average_rating") or 5
@@ -108,8 +210,9 @@ def get_interview_details(job_applicant):
 
 
 @frappe.whitelist()
-def get_applicant_to_hire_percentage():
+def get_applicant_to_hire_percentage() -> dict:
 	frappe.has_permission("Job Applicant", throw=True)
+
 	total_applicants = frappe.db.count("Job Applicant")
 	total_hired = frappe.db.count("Job Applicant", filters={"status": "Accepted"})
 

--- a/hrms/hr/doctype/job_opening/job_opening.js
+++ b/hrms/hr/doctype/job_opening/job_opening.js
@@ -12,6 +12,9 @@ frappe.ui.form.on("Job Opening", {
 		});
 	},
 	designation: function (frm) {
+		if (frm.doc.designation) {
+			frm.set_value("job_title", frm.doc.designation);
+		}
 		if (frm.doc.designation && frm.doc.company) {
 			frappe.call({
 				method: "hrms.hr.doctype.staffing_plan.staffing_plan.get_active_staffing_plan_details",
@@ -41,5 +44,65 @@ frappe.ui.form.on("Job Opening", {
 	},
 	company: function (frm) {
 		frm.set_value("designation", "");
+	},
+	status: function (frm) {
+		frm.close_warning_confirmed = false;
+	},
+	before_save: function (frm) {
+		frm.trigger("confirm_close_if_needed");
+	},
+	after_save: function (frm) {
+		frm.close_warning_confirmed = false;
+	},
+	confirm_close_if_needed: function (frm) {
+		if (frm.is_new() || frm.close_warning_confirmed || frm.doc.status !== "Closed") {
+			return;
+		}
+
+		frappe.validated = false;
+
+		frm.call("get_close_warning").then((r) => {
+			if (!r.message) {
+				frm.close_warning_confirmed = true;
+				frm.save();
+				return;
+			}
+
+			frappe.confirm(r.message, () => {
+				frm.close_warning_confirmed = true;
+				frm.save();
+			});
+		});
+	},
+
+	job_opening_template: function (frm) {
+		if (!frm.doc.job_opening_template) return;
+		frappe.db.get_doc("Job Opening Template", frm.doc.job_opening_template).then((doc) => {
+			frm.set_value({
+				designation: doc.designation,
+				department: doc.department,
+				employment_type: doc.employment_type,
+				location: doc.location,
+				description: doc.description,
+				currency: doc.currency,
+				upper_range: doc.upper_range,
+				lower_range: doc.lower_range,
+				salary_per: doc.salary_per,
+				publish_salary_range: doc.publish_salary_range,
+			});
+
+			frm.refresh_fields();
+		});
+	},
+	publish: function (frm) {
+		if (frm.doc.publish && !frm.doc.route) {
+			frm.trigger("set_route");
+		}
+	},
+	set_route: function (frm) {
+		if (frm.doc.publish && !frm.doc.route) {
+			route = `jobs/${frappe.scrub(frm.doc.company)}/${frappe.scrub(frm.doc.job_title)}`;
+			frm.set_value("route", route);
+		}
 	},
 });

--- a/hrms/hr/doctype/job_opening/job_opening.py
+++ b/hrms/hr/doctype/job_opening/job_opening.py
@@ -17,6 +17,41 @@ from hrms.hr.doctype.staffing_plan.staffing_plan import (
 
 
 class JobOpening(WebsiteGenerator):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		closed_on: DF.Date | None
+		closes_on: DF.Date | None
+		company: DF.Link
+		currency: DF.Link | None
+		department: DF.Link | None
+		description: DF.TextEditor | None
+		designation: DF.Link
+		employment_type: DF.Link | None
+		job_application_route: DF.Data | None
+		job_opening_template: DF.Link | None
+		job_requisition: DF.Link | None
+		job_title: DF.Data
+		location: DF.Link | None
+		lower_range: DF.Currency
+		planned_vacancies: DF.Int
+		posted_on: DF.Datetime | None
+		publish: DF.Check
+		publish_applications_received: DF.Check
+		publish_salary_range: DF.Check
+		route: DF.Data | None
+		salary_per: DF.Literal["Month", "Year"]
+		staffing_plan: DF.Link | None
+		status: DF.Literal["Open", "Closed"]
+		upper_range: DF.Currency
+		vacancies: DF.Int
+	# end: auto-generated types
+
 	website = frappe._dict(
 		template="templates/generators/job_opening.html",
 		condition_field="publish",
@@ -24,7 +59,7 @@ class JobOpening(WebsiteGenerator):
 	)
 
 	def autoname(self):
-		self.name = set_name_from_naming_options(frappe.get_meta(self.doctype).autoname, self)
+		set_name_from_naming_options(frappe.get_meta(self.doctype).autoname, self)
 
 	def validate(self):
 		if not self.route:
@@ -55,7 +90,26 @@ class JobOpening(WebsiteGenerator):
 		if self.status == "Closed":
 			self.validate_from_to_dates("posted_on", "closed_on")
 
+	@frappe.whitelist()
+	def get_close_warning(self):
+		if not self.is_opening_being_closed():
+			return
+
+		if not self.staffing_plan:
+			return
+
+		return _(
+			"Closing this Job Opening for {1} may not be according to the Staffing Plan {0}.<br><br>"
+			"Do you want to close this Job Opening?"
+		).format(
+			frappe.bold(get_link_to_form("Staffing Plan", self.staffing_plan)),
+			frappe.bold(self.designation),
+		)
+
 	def validate_current_vacancies(self):
+		if self.status == "Closed":
+			return
+
 		if not self.staffing_plan:
 			staffing_plan = get_active_staffing_plan_details(self.company, self.designation)
 			if staffing_plan:
@@ -87,6 +141,12 @@ class JobOpening(WebsiteGenerator):
 					),
 					title=_("Vacancies fulfilled"),
 				)
+
+	def is_opening_being_closed(self):
+		if self.is_new() or self.status != "Closed":
+			return False
+
+		return frappe.db.get_value(self.doctype, self.name, "status") == "Open"
 
 	def update_job_requisition_status(self):
 		if self.status == "Closed" and self.job_requisition:

--- a/hrms/hr/doctype/job_opening/test_job_opening.py
+++ b/hrms/hr/doctype/job_opening/test_job_opening.py
@@ -2,23 +2,18 @@
 # See license.txt
 
 import frappe
-from frappe.tests import IntegrationTestCase
 from frappe.utils import add_days, getdate
 
 from erpnext.setup.doctype.employee.test_employee import make_employee
 
 from hrms.hr.doctype.job_opening.job_opening import close_expired_job_openings
 from hrms.hr.doctype.staffing_plan.test_staffing_plan import make_company
+from hrms.tests.utils import HRMSTestSuite
 
 
-class TestJobOpening(IntegrationTestCase):
+class TestJobOpening(HRMSTestSuite):
 	def setUp(self):
-		frappe.db.delete("Staffing Plan")
-		frappe.db.delete("Staffing Plan Detail")
-		frappe.db.delete("Job Opening")
-
 		make_company("_Test Opening Company", "_TOC")
-		frappe.db.delete("Employee", {"company": "_Test Opening Company"})
 
 	def test_vacancies_fulfilled(self):
 		make_employee("test_job_opening@example.com", company="_Test Opening Company", designation="Designer")
@@ -53,6 +48,70 @@ class TestJobOpening(IntegrationTestCase):
 		# allows updating existing job opening
 		opening_1.status = "Closed"
 		opening_1.save()
+
+	def test_close_job_opening_after_employee_creation(self):
+		staffing_plan = frappe.get_doc(
+			{
+				"doctype": "Staffing Plan",
+				"company": "_Test Opening Company",
+				"name": "Test",
+				"from_date": getdate(),
+				"to_date": add_days(getdate(), 10),
+			}
+		)
+
+		staffing_plan.append(
+			"staffing_details",
+			{"designation": "Designer", "vacancies": 1, "estimated_cost_per_position": 50000},
+		)
+		staffing_plan.insert()
+		staffing_plan.submit()
+
+		opening = get_job_opening()
+		opening.insert()
+
+		make_employee(
+			"test_job_opening_after_hiring@example.com",
+			company="_Test Opening Company",
+			designation="Designer",
+		)
+
+		opening.status = "Closed"
+		close_warning = opening.get_close_warning()
+		self.assertIn("may not be according to the Staffing Plan", close_warning)
+		self.assertNotIn("<table", close_warning)
+		self.assertIn("Designer", close_warning)
+		self.assertIn("<strong><a", close_warning)
+		opening.save()
+
+		self.assertEqual(opening.status, "Closed")
+
+	def test_close_job_opening_under_staffing_plan_shows_warning(self):
+		staffing_plan = frappe.get_doc(
+			{
+				"doctype": "Staffing Plan",
+				"company": "_Test Opening Company",
+				"name": "Test",
+				"from_date": getdate(),
+				"to_date": add_days(getdate(), 10),
+			}
+		)
+
+		staffing_plan.append(
+			"staffing_details",
+			{"designation": "Designer", "vacancies": 3, "estimated_cost_per_position": 50000},
+		)
+		staffing_plan.insert()
+		staffing_plan.submit()
+
+		opening = get_job_opening(job_title="Designer Under Plan")
+		opening.insert()
+
+		opening.status = "Closed"
+		self.assertIn("may not be according to the Staffing Plan", opening.get_close_warning())
+		opening.save()
+
+		self.assertEqual(opening.status, "Closed")
 
 	def test_close_expired_job_openings(self):
 		today = getdate()

--- a/hrms/hr/doctype/job_requisition/job_requisition.py
+++ b/hrms/hr/doctype/job_requisition/job_requisition.py
@@ -9,12 +9,43 @@ from frappe.utils import format_duration, get_link_to_form, time_diff_in_seconds
 
 
 class JobRequisition(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		company: DF.Link
+		completed_on: DF.Date | None
+		department: DF.Link | None
+		description: DF.TextEditor
+		designation: DF.Link
+		expected_by: DF.Date | None
+		expected_compensation: DF.Currency
+		naming_series: DF.Literal["HR-HIREQ-"]
+		no_of_positions: DF.Int
+		posting_date: DF.Date
+		reason_for_requesting: DF.Text | None
+		requested_by: DF.Link
+		requested_by_dept: DF.Link | None
+		requested_by_designation: DF.Link | None
+		requested_by_name: DF.Data | None
+		status: DF.Literal["Pending", "Open & Approved", "Rejected", "Filled", "On Hold", "Cancelled"]
+		time_to_fill: DF.Duration | None
+	# end: auto-generated types
+
 	def validate(self):
-		self.validate_duplicates()
 		self.set_time_to_fill()
 
-	def validate_duplicates(self):
-		duplicate = frappe.db.exists(
+	def set_time_to_fill(self):
+		if self.status == "Filled" and self.completed_on:
+			self.time_to_fill = time_diff_in_seconds(self.completed_on, self.posting_date)
+
+	@frappe.whitelist()
+	def check_duplicate_job_requisition(self):
+		return frappe.db.exists(
 			"Job Requisition",
 			{
 				"designation": self.designation,
@@ -25,22 +56,9 @@ class JobRequisition(Document):
 			},
 		)
 
-		if duplicate:
-			frappe.throw(
-				_("A Job Requisition for {0} requested by {1} already exists: {2}").format(
-					frappe.bold(self.designation),
-					frappe.bold(self.requested_by),
-					get_link_to_form("Job Requisition", duplicate),
-				),
-				title=_("Duplicate Job Requisition"),
-			)
-
-	def set_time_to_fill(self):
-		if self.status == "Filled" and self.completed_on:
-			self.time_to_fill = time_diff_in_seconds(self.completed_on, self.posting_date)
-
 	@frappe.whitelist()
-	def associate_job_opening(self, job_opening):
+	def associate_job_opening(self, job_opening: str) -> None:
+		frappe.has_permission("Job Opening", "write", job_opening, throw=True)
 		frappe.db.set_value(
 			"Job Opening", job_opening, {"job_requisition": self.name, "vacancies": self.no_of_positions}
 		)
@@ -53,7 +71,7 @@ class JobRequisition(Document):
 
 
 @frappe.whitelist()
-def make_job_opening(source_name, target_doc=None):
+def make_job_opening(source_name: str, target_doc: str | Document | None = None) -> Document:
 	def set_missing_values(source, target):
 		target.job_title = source.designation
 		target.status = "Open"
@@ -95,7 +113,7 @@ def get_avg_time_to_fill(
 	avg_time_to_fill = frappe.db.get_list(
 		"Job Requisition",
 		filters=filters,
-		fields=["avg(time_to_fill) as average_time"],
+		fields=[{"AVG": "time_to_fill", "as": "average_time"}],
 	)[0].average_time
 
 	return format_duration(avg_time_to_fill) if avg_time_to_fill else 0

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.py
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
-
+import datetime
 
 import frappe
 from frappe import _
@@ -11,6 +11,7 @@ from hrms.hr.doctype.leave_application.leave_application import get_approved_lea
 from hrms.hr.doctype.leave_ledger_entry.leave_ledger_entry import (
 	create_leave_ledger_entry,
 	expire_allocation,
+	process_expired_allocation,
 )
 from hrms.hr.utils import create_additional_leave_ledger_entry, get_leave_period, set_employee_name
 from hrms.hr.utils import get_monthly_earned_leave as _get_monthly_earned_leave
@@ -37,6 +38,40 @@ class ValueMultiplierError(frappe.ValidationError):
 
 
 class LeaveAllocation(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from hrms.hr.doctype.earned_leave_schedule.earned_leave_schedule import EarnedLeaveSchedule
+
+		amended_from: DF.Link | None
+		carry_forward: DF.Check
+		carry_forwarded_leaves_count: DF.Float
+		company: DF.Link
+		compensatory_request: DF.Link | None
+		department: DF.Link | None
+		description: DF.SmallText | None
+		earned_leave_schedule: DF.Table[EarnedLeaveSchedule]
+		employee: DF.Link
+		employee_name: DF.Data | None
+		expired: DF.Check
+		from_date: DF.Date
+		leave_period: DF.Link | None
+		leave_policy: DF.Link | None
+		leave_policy_assignment: DF.Link | None
+		leave_type: DF.Link
+		naming_series: DF.Literal["HR-LAL-.YYYY.-"]
+		new_leaves_allocated: DF.Float
+		to_date: DF.Date
+		total_leaves_allocated: DF.Float
+		total_leaves_encashed: DF.Float
+		unused_leaves: DF.Float
+	# end: auto-generated types
+
 	def validate(self):
 		self.validate_period()
 		self.validate_allocation_overlap()
@@ -127,7 +162,7 @@ class LeaveAllocation(Document):
 				"is_carry_forward": 0,
 				"docstatus": 1,
 			},
-			fields=["SUM(leaves) as total_leaves"],
+			fields=[{"SUM": "leaves", "as": "total_leaves"}],
 		)
 
 		return ledger_entries[0].total_leaves if ledger_entries else 0
@@ -185,17 +220,19 @@ class LeaveAllocation(Document):
 			)
 
 	def validate_allocation_overlap(self):
-		leave_allocation = frappe.db.sql(
-			"""
-			SELECT
-				name
-			FROM `tabLeave Allocation`
-			WHERE
-				employee=%s AND leave_type=%s
-				AND name <> %s AND docstatus=1
-				AND to_date >= %s AND from_date <= %s""",
-			(self.employee, self.leave_type, self.name, self.from_date, self.to_date),
-		)
+		LeaveAllocation = frappe.qb.DocType("Leave Allocation")
+		leave_allocation = (
+			frappe.qb.from_(LeaveAllocation)
+			.select(LeaveAllocation.name)
+			.where(
+				(LeaveAllocation.employee == self.employee)
+				& (LeaveAllocation.leave_type == self.leave_type)
+				& (LeaveAllocation.name != self.name)
+				& (LeaveAllocation.docstatus == 1)
+				& (LeaveAllocation.to_date >= self.from_date)
+				& (LeaveAllocation.from_date <= self.to_date)
+			)
+		).run()
 
 		if leave_allocation:
 			frappe.msgprint(
@@ -211,13 +248,18 @@ class LeaveAllocation(Document):
 			)
 
 	def validate_back_dated_allocation(self):
-		future_allocation = frappe.db.sql(
-			"""select name, from_date from `tabLeave Allocation`
-			where employee=%s and leave_type=%s and docstatus=1 and from_date > %s
-			and carry_forward=1""",
-			(self.employee, self.leave_type, self.to_date),
-			as_dict=1,
-		)
+		LeaveAllocation = frappe.qb.DocType("Leave Allocation")
+		future_allocation = (
+			frappe.qb.from_(LeaveAllocation)
+			.select(LeaveAllocation.name, LeaveAllocation.from_date)
+			.where(
+				(LeaveAllocation.employee == self.employee)
+				& (LeaveAllocation.leave_type == self.leave_type)
+				& (LeaveAllocation.docstatus == 1)
+				& (LeaveAllocation.from_date > self.to_date)
+				& (LeaveAllocation.carry_forward == 1)
+			)
+		).run(as_dict=True)
 
 		if future_allocation:
 			frappe.throw(
@@ -248,6 +290,7 @@ class LeaveAllocation(Document):
 			not self.total_leaves_allocated
 			and not frappe.db.get_value("Leave Type", self.leave_type, "is_earned_leave")
 			and not frappe.db.get_value("Leave Type", self.leave_type, "is_compensatory")
+			and not frappe.db.get_value("Leave Type", self.leave_type, "allow_negative")
 		):
 			frappe.throw(_("Total leaves allocated is mandatory for Leave Type {0}").format(self.leave_type))
 
@@ -316,7 +359,8 @@ class LeaveAllocation(Document):
 		create_leave_ledger_entry(self, args, submit)
 
 	@frappe.whitelist()
-	def allocate_leaves_manually(self, new_leaves, from_date=None):
+	def allocate_leaves_manually(self, new_leaves: str | float, from_date: str | datetime.date | None = None):
+		self.check_permission("write")
 		if from_date and not (getdate(self.from_date) <= getdate(from_date) <= getdate(self.to_date)):
 			frappe.throw(
 				_("Cannot allocate leaves outside the allocation period {0} - {1}").format(
@@ -324,7 +368,7 @@ class LeaveAllocation(Document):
 				),
 				title=_("Invalid Dates"),
 			)
-		
+
 		new_allocation = flt(self.total_leaves_allocated) + flt(new_leaves)
 		new_allocation_without_cf = flt(
 			flt(self.get_existing_leave_count()) + flt(new_leaves),
@@ -361,6 +405,7 @@ class LeaveAllocation(Document):
 				indicator="green",
 				alert=True,
 			)
+
 		else:
 			msg = _("Total leaves allocated cannot exceed annual allocation of {0}.").format(
 				frappe.bold(_(annual_allocation))
@@ -392,6 +437,87 @@ class LeaveAllocation(Document):
 		)
 
 		return _get_monthly_earned_leave(doj, annual_allocation, frequency, rounding)
+
+	@frappe.whitelist()
+	def create_leave_adjustment(
+		self,
+		adjustment_type: str,
+		leaves_to_adjust: str | float,
+		posting_date: str | datetime.date,
+		reason_for_adjustment: str | None = None,
+	) -> None:
+		leave_adjustment = frappe.new_doc(
+			"Leave Adjustment",
+			employee=self.employee,
+			leave_type=self.leave_type,
+			adjustment_type=adjustment_type,
+			leaves_to_adjust=leaves_to_adjust,
+			posting_date=posting_date,
+			leave_allocation=self.name,
+			reason_for_adjustment=reason_for_adjustment,
+		)
+		leave_adjustment.save()
+		leave_adjustment.submit()
+		frappe.msgprint(_("Adjustment Created Successfully"), indicator="green", alert=True)
+
+	@frappe.whitelist()
+	def retry_failed_allocations(self, failed_allocations: list) -> None:
+		if not frappe.has_permission(doctype="Leave Allocation", ptype="write", user=frappe.session.user):
+			frappe.throw(_("You do not have permission to complete this action"), frappe.PermissionError)
+
+		max_leaves_allowed, frequency = frappe.db.get_values(
+			"Leave Type", self.leave_type, ["max_leaves_allowed", "earned_leave_frequency"]
+		)[0]
+
+		annual_allocation = frappe.get_value(
+			"Leave Policy Detail",
+			{"parent": self.leave_policy, "leave_type": self.leave_type},
+			"annual_allocation",
+		)
+
+		for allocation in failed_allocations:
+			new_allocation = flt(self.total_leaves_allocated) + flt(allocation["number_of_leaves"])
+
+			new_allocation_without_cf = flt(self.get_existing_leave_count()) + flt(
+				allocation["number_of_leaves"]
+			)
+
+			if new_allocation > max_leaves_allowed and max_leaves_allowed > 0:
+				frappe.throw(
+					msg=_(
+						"Cannot allocate more leaves due to maximum leaves allowed limit of {0} in {1} leave type."
+					).format(frappe.bold(max_leaves_allowed), frappe.bold(self.leave_type)),
+					title=_("Retry Failed"),
+				)
+
+			elif new_allocation_without_cf > annual_allocation and frequency != "Yearly":
+				frappe.throw(
+					msg=_(
+						"Cannot allocate more leaves due to maximum leave allocation limit of {0} in leave policy assignment"
+					).format(frappe.bold(annual_allocation)),
+					title=_("Retry Failed"),
+				)
+
+			else:
+				self.db_set("total_leaves_allocated", new_allocation, update_modified=False)
+				create_additional_leave_ledger_entry(
+					self, allocation["number_of_leaves"], allocation["allocation_date"]
+				)
+				earned_leave_schedule = frappe.qb.DocType("Earned Leave Schedule")
+				(
+					frappe.qb.update(earned_leave_schedule)
+					.where(
+						(earned_leave_schedule.parent == self.name)
+						& (earned_leave_schedule.allocation_date == allocation["allocation_date"])
+						& (earned_leave_schedule.attempted == 1)
+						& (earned_leave_schedule.failed == 1)
+					)
+					.set(earned_leave_schedule.is_allocated, 1)
+					.set(earned_leave_schedule.attempted, 1)
+					.set(earned_leave_schedule.allocated_via, "Manually")
+					.set(earned_leave_schedule.failed, 0)
+					.set(earned_leave_schedule.failure_reason, "")
+				).run()
 
 
 def get_previous_allocation(from_date, leave_type, employee):
@@ -470,7 +596,7 @@ def get_unused_leaves(employee, leave_type, from_date, to_date):
 			"to_date": ("<=", to_date),
 		},
 		or_filters={"is_expired": 0, "is_carry_forward": 1},
-		fields=["sum(leaves) as leaves"],
+		fields=[{"SUM": "leaves", "as": "leaves"}],
 	)
 	return flt(leaves[0]["leaves"])
 
@@ -498,8 +624,6 @@ def show_expire_leave_dialog(expired_leaves, leave_type):
 @frappe.whitelist()
 def expire_carried_forward_allocation():
 	if frappe.has_permission(doctype="Leave Allocation", ptype="submit", user=frappe.session.user):
-		from hrms.hr.doctype.leave_ledger_entry.leave_ledger_entry import process_expired_allocation
-
 		process_expired_allocation()
 	else:
 		frappe.throw(_("You do not have permission to complete this action"), frappe.PermissionError)

--- a/hrms/hr/doctype/leave_encashment/leave_encashment.js
+++ b/hrms/hr/doctype/leave_encashment/leave_encashment.js
@@ -24,6 +24,7 @@ frappe.ui.form.on("Leave Encashment", {
 				},
 			};
 		});
+
 		frm.set_query("payable_account", function () {
 			if (!frm.doc.employee) {
 				frappe.msgprint(__("Please select employee first"));
@@ -42,12 +43,23 @@ frappe.ui.form.on("Leave Encashment", {
 				},
 			};
 		});
+
+		frm.set_query("expense_account", function () {
+			return {
+				filters: {
+					is_group: 0,
+					root_type: "Expense",
+					company: frm.doc.company,
+				},
+			};
+		});
 	},
 	refresh: function (frm) {
 		cur_frm.set_intro("");
 		if (frm.doc.__islocal && !frappe.user_roles.includes("Employee")) {
 			frm.set_intro(__("Fill the form and save it"));
 		}
+
 		if (
 			frm.doc.docstatus === 1 &&
 			frm.doc.pay_via_payment_entry == 1 &&
@@ -61,6 +73,7 @@ frappe.ui.form.on("Leave Encashment", {
 				__("Create"),
 			);
 		}
+
 		hrms.leave_utils.add_view_ledger_button(frm);
 	},
 	employee: function (frm) {
@@ -106,19 +119,6 @@ frappe.ui.form.on("Leave Encashment", {
 					frm.set_value("currency", r.message);
 					frm.refresh_fields();
 				}
-			},
-		});
-	},
-	make_payment_entry: function (frm) {
-		return frappe.call({
-			method:"hrms.overrides.employee_payment_entry.get_payment_entry_for_employee",
-			args: {
-				dt: frm.doc.doctype,
-				dn: frm.doc.name,
-			},
-			callback: function (r) {
-				var doclist = frappe.model.sync(r.message);
-				frappe.set_route("Form", doclist[0].doctype, doclist[0].name);
 			},
 		});
 	},

--- a/hrms/hr/doctype/leave_encashment/leave_encashment.json
+++ b/hrms/hr/doctype/leave_encashment/leave_encashment.json
@@ -204,8 +204,9 @@
   },
   {
    "fieldname": "column_break_vdnb",
-   "fieldtype": "Column Break"},
-   {
+   "fieldtype": "Column Break"
+  },
+  {
    "default": "0.0",
    "depends_on": "pay_via_payment_entry",
    "description": "Amount paid against this encashment",
@@ -256,8 +257,17 @@
   }
  ],
  "is_submittable": 1,
- "links": [],
- "modified": "2024-03-27 13:10:01.094420",
+ "links": [
+  {
+   "group": "Payment",
+   "is_child_table": 1,
+   "link_doctype": "Payment Entry Reference",
+   "link_fieldname": "reference_name",
+   "parent_doctype": "Payment Entry",
+   "table_fieldname": "references"
+  }
+ ],
+ "modified": "2026-06-24 11:34:04.610000",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Leave Encashment",
@@ -325,7 +335,8 @@
  "search_fields": "employee,employee_name",
  "sort_field": "creation",
  "sort_order": "DESC",
- "states": [ {
+ "states": [
+  {
    "color": "Red",
    "title": "Draft"
   },
@@ -340,7 +351,8 @@
   {
    "color": "Red",
    "title": "Cancelled"
-  }],
+  }
+ ],
  "title_field": "employee_name",
  "track_changes": 1
 }

--- a/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
+++ b/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
@@ -1,5 +1,8 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
+import datetime
+
+from pypika.terms import ExistsCriterion
 
 import frappe
 from frappe import _
@@ -12,6 +15,30 @@ class InvalidLeaveLedgerEntry(frappe.ValidationError):
 
 
 class LeaveLedgerEntry(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		amended_from: DF.Link | None
+		company: DF.Link
+		employee: DF.Link | None
+		employee_name: DF.Data | None
+		from_date: DF.Date | None
+		holiday_list: DF.Link | None
+		is_carry_forward: DF.Check
+		is_expired: DF.Check
+		is_lwp: DF.Check
+		leave_type: DF.Link | None
+		leaves: DF.Float
+		to_date: DF.Date | None
+		transaction_name: DF.DynamicLink | None
+		transaction_type: DF.Link | None
+	# end: auto-generated types
+
 	def validate(self):
 		if getdate(self.from_date) > getdate(self.to_date):
 			frappe.throw(
@@ -29,25 +56,24 @@ class LeaveLedgerEntry(Document):
 		# allow cancellation of expiry leaves
 		if self.is_expired:
 			frappe.db.set_value("Leave Allocation", self.transaction_name, "expired", 0)
-		else:
+		elif self.transaction_type != "Leave Adjustment":
 			frappe.throw(_("Only expired allocation can be cancelled"))
 
 
 def validate_leave_allocation_against_leave_application(ledger):
 	"""Checks that leave allocation has no leave application against it"""
-	leave_application_records = frappe.db.sql_list(
-		"""
-		SELECT transaction_name
-		FROM `tabLeave Ledger Entry`
-		WHERE
-			employee=%s
-			AND leave_type=%s
-			AND transaction_type='Leave Application'
-			AND from_date>=%s
-			AND to_date<=%s
-	""",
-		(ledger.employee, ledger.leave_type, ledger.from_date, ledger.to_date),
-	)
+	Ledger = frappe.qb.DocType("Leave Ledger Entry")
+	leave_application_records = (
+		frappe.qb.from_(Ledger)
+		.select(Ledger.transaction_name)
+		.where(
+			(Ledger.employee == ledger.employee)
+			& (Ledger.leave_type == ledger.leave_type)
+			& (Ledger.transaction_type == "Leave Application")
+			& (Ledger.from_date >= ledger.from_date)
+			& (Ledger.to_date <= ledger.to_date)
+		)
+	).run(pluck=True)
 
 	if leave_application_records:
 		frappe.throw(
@@ -89,14 +115,12 @@ def delete_ledger_entry(ledger):
 		validate_leave_allocation_against_leave_application(ledger)
 
 	expired_entry = get_previous_expiry_ledger_entry(ledger)
-	frappe.db.sql(
-		"""DELETE
-		FROM `tabLeave Ledger Entry`
-		WHERE
-			`transaction_name`=%s
-			OR `name`=%s""",
-		(ledger.transaction_name, expired_entry),
-	)
+	Ledger = frappe.qb.DocType("Leave Ledger Entry")
+	(
+		frappe.qb.from_(Ledger)
+		.delete()
+		.where((Ledger.transaction_name == ledger.transaction_name) | (Ledger.name == expired_entry))
+	).run()
 
 
 def get_previous_expiry_ledger_entry(ledger):
@@ -130,44 +154,55 @@ def get_previous_expiry_ledger_entry(ledger):
 def process_expired_allocation():
 	"""Check if a carry forwarded allocation has expired and create a expiry ledger entry
 	Case 1: carry forwarded expiry period is set for the leave type,
-			create a separate leave expiry entry against each entry of carry forwarded and non carry forwarded leaves
+	        create a separate leave expiry entry against each entry of carry forwarded and non carry forwarded leaves
 	Case 2: leave type has no specific expiry period for carry forwarded leaves
-			and there is no carry forwarded leave allocation, create a single expiry against the remaining leaves.
+	        and there is no carry forwarded leave allocation, create a single expiry against the remaining leaves.
 	"""
 
 	# fetch leave type records that has carry forwarded leaves expiry
 	leave_type_records = frappe.db.get_values(
-		"Leave Type",
-		filters={"expire_carry_forwarded_leaves_after_days": (">", 0)},
-		fieldname=["name"],
+		"Leave Type", filters={"expire_carry_forwarded_leaves_after_days": (">", 0)}, fieldname=["name"]
 	)
 
 	leave_type = [record[0] for record in leave_type_records] or [""]
 
 	# fetch non expired leave ledger entry of transaction_type allocation
-	expire_allocation = frappe.db.sql(
-		"""
-		SELECT
-			leaves, to_date, from_date, employee, leave_type,
-			is_carry_forward, transaction_name as name, transaction_type
-		FROM `tabLeave Ledger Entry` l
-		WHERE (NOT EXISTS
-			(SELECT name
-				FROM `tabLeave Ledger Entry`
-				WHERE
-					transaction_name = l.transaction_name
-					AND transaction_type = 'Leave Allocation'
-					AND name<>l.name
-					AND docstatus = 1
-					AND (
-						is_carry_forward=l.is_carry_forward
-						OR (is_carry_forward = 0 AND leave_type not in %s)
-			)))
-			AND transaction_type = 'Leave Allocation'
-			AND to_date < %s""",
-		(leave_type, today()),
-		as_dict=1,
+	Ledger = frappe.qb.DocType("Leave Ledger Entry").as_("l")
+	InnerLedger = frappe.qb.DocType("Leave Ledger Entry")
+
+	inner_query = (
+		frappe.qb.from_(InnerLedger)
+		.select(InnerLedger.name)
+		.where(
+			(InnerLedger.transaction_name == Ledger.transaction_name)
+			& (InnerLedger.transaction_type == "Leave Allocation")
+			& (InnerLedger.name != Ledger.name)
+			& (InnerLedger.docstatus == 1)
+			& (
+				(InnerLedger.is_carry_forward == Ledger.is_carry_forward)
+				| ((InnerLedger.is_carry_forward == 0) & (InnerLedger.leave_type.notin(leave_type)))
+			)
+		)
 	)
+
+	expire_allocation = (
+		frappe.qb.from_(Ledger)
+		.select(
+			Ledger.leaves,
+			Ledger.to_date,
+			Ledger.from_date,
+			Ledger.employee,
+			Ledger.leave_type,
+			Ledger.is_carry_forward,
+			Ledger.transaction_name.as_("name"),
+			Ledger.transaction_type,
+		)
+		.where(
+			ExistsCriterion(inner_query).negate()
+			& (Ledger.transaction_type == "Leave Allocation")
+			& (Ledger.to_date < today())
+		)
+	).run(as_dict=1)
 
 	if expire_allocation:
 		create_expiry_ledger_entry(expire_allocation)
@@ -192,12 +227,12 @@ def get_remaining_leaves(allocation):
 			"to_date": ("<=", allocation.to_date),
 			"docstatus": 1,
 		},
-		fieldname=["SUM(leaves)"],
+		fieldname=[{"SUM": "leaves"}],
 	)
 
 
 @frappe.whitelist()
-def expire_allocation(allocation, expiry_date=None):
+def expire_allocation(allocation: str | Document | frappe._dict, expiry_date: datetime.date | None = None):
 	"""expires non-carry forwarded allocation"""
 	import json
 
@@ -205,12 +240,10 @@ def expire_allocation(allocation, expiry_date=None):
 		allocation = json.loads(allocation)
 		allocation = frappe.get_doc("Leave Allocation", allocation["name"])
 
-	leaves = get_remaining_leaves(allocation)
-	expiry_date = expiry_date if expiry_date else allocation.to_date
+	if getattr(allocation, "docstatus", 0) == 2:
+		return
 
-	if isinstance(allocation, str):
-		allocation = json.loads(allocation)
-		allocation = frappe.get_doc("Leave Allocation", allocation["name"])
+	frappe.has_permission("Leave Allocation", "write", allocation.name, throw=True)
 
 	leaves = get_remaining_leaves(allocation)
 	expiry_date = expiry_date if expiry_date else allocation.to_date
@@ -233,9 +266,7 @@ def expire_allocation(allocation, expiry_date=None):
 
 def expire_carried_forward_allocation(allocation):
 	"""Expires remaining leaves in the on carried forward allocation"""
-	from hrms.hr.doctype.leave_application.leave_application import (
-		get_leaves_for_period,
-	)
+	from hrms.hr.doctype.leave_application.leave_application import get_leaves_for_period
 
 	leaves_taken = get_leaves_for_period(
 		allocation.employee,

--- a/hrms/hr/doctype/overtime_slip/overtime_slip.js
+++ b/hrms/hr/doctype/overtime_slip/overtime_slip.js
@@ -1,0 +1,51 @@
+// Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Overtime Slip", {
+	refresh: async (frm) => {
+		if (frm.doc.docstatus === 0) {
+			frm.add_custom_button(__("Fetch Overtime Details"), () => {
+				if (!frm.doc.employee || !frm.doc.posting_date || !frm.doc.company) {
+					frappe.msgprint({
+						title: __("Missing Fields"),
+						message: __(
+							"Please fill in Employee, Posting Date, and Company before fetching overtime details.",
+						),
+						indicator: "orange",
+					});
+				} else {
+					frm.events.get_emp_details_and_overtime_duration(frm);
+				}
+			});
+		}
+	},
+
+	employee(frm) {
+		frm.events.set_frequency_and_dates(frm);
+	},
+	posting_date(frm) {
+		frm.events.set_frequency_and_dates(frm);
+	},
+	set_frequency_and_dates: function (frm) {
+		if (frm.doc.employee && frm.doc.posting_date) {
+			return frappe.call({
+				method: "get_frequency_and_dates",
+				doc: frm.doc,
+				callback: function () {
+					frm.refresh();
+				},
+			});
+		}
+	},
+	get_emp_details_and_overtime_duration: function (frm) {
+		if (frm.doc.employee) {
+			return frappe.call({
+				method: "get_emp_and_overtime_details",
+				doc: frm.doc,
+				callback: function () {
+					frm.refresh();
+				},
+			});
+		}
+	},
+});

--- a/hrms/hr/doctype/overtime_slip/overtime_slip.json
+++ b/hrms/hr/doctype/overtime_slip/overtime_slip.json
@@ -1,0 +1,219 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "HR-OT-SLIP-.#####",
+ "creation": "2024-10-15 16:19:55.229439",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_wdfp",
+  "posting_date",
+  "employee",
+  "employee_name",
+  "column_break_xsxd",
+  "company",
+  "department",
+  "amended_from",
+  "section_break_fvyh",
+  "start_date",
+  "end_date",
+  "salary_slip",
+  "column_break_sdpb",
+  "total_overtime_duration",
+  "payroll_entry",
+  "submitted_via_payroll_entry",
+  "section_break_dzua",
+  "overtime_details"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_wdfp",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Overtime Slip",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "default": "Today",
+   "fieldname": "posting_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Posting Date",
+   "reqd": 1
+  },
+  {
+   "fieldname": "employee",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Employee",
+   "options": "Employee",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "employee.employee_name",
+   "fieldname": "employee_name",
+   "fieldtype": "Data",
+   "label": "Employee Name"
+  },
+  {
+   "fieldname": "column_break_xsxd",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "employee.department",
+   "fieldname": "department",
+   "fieldtype": "Link",
+   "label": "Department",
+   "options": "Department"
+  },
+  {
+   "fetch_from": "employee.company",
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company",
+   "reqd": 1
+  },
+  {
+   "fieldname": "section_break_fvyh",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_sdpb",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_dzua",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "overtime_details",
+   "fieldtype": "Table",
+   "label": "Overtime Details",
+   "options": "Overtime Details",
+   "reqd": 1
+  },
+  {
+   "fieldname": "total_overtime_duration",
+   "fieldtype": "Float",
+   "label": "Total Overtime Duration",
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "salary_slip",
+   "fieldtype": "Link",
+   "ignore_user_permissions": 1,
+   "label": "Salary Slip",
+   "options": "Salary Slip",
+   "read_only": 1
+  },
+  {
+   "fieldname": "start_date",
+   "fieldtype": "Date",
+   "label": "Start Date",
+   "reqd": 1
+  },
+  {
+   "fieldname": "end_date",
+   "fieldtype": "Date",
+   "label": "End Date",
+   "reqd": 1
+  },
+  {
+   "depends_on": "payroll_entry",
+   "fieldname": "payroll_entry",
+   "fieldtype": "Link",
+   "label": "Payroll Entry",
+   "options": "Payroll Entry",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "submitted_via_payroll_entry",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Submitted via Payroll Entry"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "is_submittable": 1,
+ "links": [
+  {
+   "link_doctype": "Additional Salary",
+   "link_fieldname": "ref_docname"
+  }
+ ],
+ "modified": "2025-08-11 17:02:10.282104",
+ "modified_by": "Administrator",
+ "module": "HR",
+ "name": "Overtime Slip",
+ "naming_rule": "Expression (old style)",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Employee",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "HR User",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Leave Approver",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "employee_name"
+}

--- a/hrms/hr/doctype/overtime_slip/overtime_slip.py
+++ b/hrms/hr/doctype/overtime_slip/overtime_slip.py
@@ -1,0 +1,538 @@
+# Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+import json
+from datetime import timedelta
+from email.utils import formatdate
+
+import frappe
+from frappe import _, bold
+from frappe.model.docstatus import DocStatus
+from frappe.model.document import Document
+from frappe.utils import cstr, flt
+from frappe.utils.data import format_time, get_link_to_form, getdate
+
+from hrms.payroll.doctype.payroll_entry.payroll_entry import get_start_end_dates
+from hrms.payroll.doctype.salary_structure_assignment.salary_structure_assignment import (
+	get_assigned_salary_structure,
+)
+
+
+class OvertimeSlip(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from hrms.hr.doctype.overtime_details.overtime_details import OvertimeDetails
+
+		amended_from: DF.Link | None
+		company: DF.Link
+		department: DF.Link | None
+		employee: DF.Link
+		employee_name: DF.Data | None
+		end_date: DF.Date
+		overtime_details: DF.Table[OvertimeDetails]
+		payroll_entry: DF.Link | None
+		posting_date: DF.Date
+		salary_slip: DF.Link | None
+		start_date: DF.Date
+		submitted_via_payroll_entry: DF.Check
+		total_overtime_duration: DF.Float
+	# end: auto-generated types
+
+	def validate(self):
+		if not (self.start_date or self.end_date):
+			self.get_frequency_and_dates()
+
+		if self.start_date > self.end_date:
+			frappe.throw(_("Start date cannot be greater than end date"))
+
+		self.validate_overlap()
+		self.validate_overtime_date_and_duration()
+
+	def on_submit(self):
+		self.process_overtime_slip()
+
+	def validate_overlap(self):
+		overtime_slips = frappe.db.get_all(
+			"Overtime Slip",
+			filters={
+				"docstatus": ("!=", 2),
+				"employee": self.employee,
+				"end_date": (">=", self.start_date),
+				"start_date": ("<=", self.end_date),
+				"name": ("!=", self.name),
+			},
+		)
+		if len(overtime_slips):
+			form_link = get_link_to_form("Overtime Slip", overtime_slips[0].name)
+			msg = _("Overtime Slip:{0} has been created between {1} and {2}").format(
+				bold(form_link), bold(self.start_date), bold(self.end_date)
+			)
+			frappe.throw(msg)
+
+	def validate_overtime_date_and_duration(self):
+		dates = set()
+		overtime_type_cache = {}
+		for detail in self.overtime_details:
+			# check for duplicate dates
+			if detail.date in dates:
+				frappe.throw(_("Date {0} is repeated in Overtime Details").format(detail.date))
+			dates.add(detail.date)
+			# validate duration only for overtime details not linked to attendance
+			if detail.reference_document:
+				continue
+
+			if detail.overtime_type not in overtime_type_cache:
+				overtime_type_cache[detail.overtime_type] = frappe.db.get_value(
+					"Overtime Type", detail.overtime_type, "maximum_overtime_hours_allowed"
+				)
+			maximum_overtime_hours = overtime_type_cache[detail.overtime_type]
+			if maximum_overtime_hours:
+				if detail.overtime_duration > maximum_overtime_hours:
+					frappe.throw(
+						_("Overtime Duration for {0} is greater than Maximum Overtime Hours Allowed").format(
+							detail.date
+						)
+					)
+
+	@frappe.whitelist()
+	def get_frequency_and_dates(self):
+		date = self.posting_date
+
+		salary_structure = get_assigned_salary_structure(self.employee, date)
+		if salary_structure:
+			payroll_frequency = frappe.db.get_value("Salary Structure", salary_structure, "payroll_frequency")
+			date_details = get_start_end_dates(
+				payroll_frequency, date, frappe.db.get_value("Employee", self.employee, "company")
+			)
+			self.start_date = date_details.start_date
+			self.end_date = date_details.end_date
+		else:
+			frappe.throw(
+				_("Salary Structure not assigned for employee {0} for date {1}").format(
+					self.employee, self.start_date
+				)
+			)
+
+	@frappe.whitelist()
+	def get_emp_and_overtime_details(self):
+		records = self.get_attendance_records()
+		if len(records):
+			self.create_overtime_details_row_for_attendance(records)
+		if len(self.overtime_details):
+			total_overtime_duration = 0.0
+			for detail in self.overtime_details:
+				if detail.overtime_duration is not None:
+					total_overtime_duration += detail.overtime_duration
+			self.total_overtime_duration = total_overtime_duration
+		self.save()
+
+	def create_overtime_details_row_for_attendance(self, records):
+		self.overtime_details = []
+		overtime_type_cache = {}
+
+		for record in records:
+			if record.overtime_type not in overtime_type_cache:
+				overtime_type_cache[record.overtime_type] = frappe.db.get_value(
+					"Overtime Type", record.overtime_type, "maximum_overtime_hours_allowed"
+				)
+
+			maximum_overtime_hours_allowed = overtime_type_cache[record.overtime_type]
+			overtime_duration = record.actual_overtime_duration or 0.0
+
+			if maximum_overtime_hours_allowed > 0:
+				overtime_duration = (
+					overtime_duration
+					if maximum_overtime_hours_allowed > overtime_duration
+					else maximum_overtime_hours_allowed
+				)
+
+			if overtime_duration > 0:
+				self.append(
+					"overtime_details",
+					{
+						"reference_document": record.name,
+						"date": record.attendance_date,
+						"overtime_type": record.overtime_type,
+						"overtime_duration": overtime_duration,
+						"standard_working_hours": record.standard_working_hours,
+					},
+				)
+
+	def get_attendance_records(self):
+		records = []
+		if self.start_date and self.end_date:
+			records = frappe.get_all(
+				"Attendance",
+				fields=[
+					"name",
+					"attendance_date",
+					"overtime_type",
+					"actual_overtime_duration",
+					"standard_working_hours",
+				],
+				filters={
+					"employee": self.employee,
+					"docstatus": 1,
+					"attendance_date": ("between", [getdate(self.start_date), getdate(self.end_date)]),
+					"status": "Present",
+					"overtime_type": ["!=", ""],
+				},
+			)
+			if not len(records):
+				frappe.throw(
+					_("No attendance records found for employee {0} between {1} and {2}").format(
+						self.employee, self.start_date, self.end_date
+					)
+				)
+		return records
+
+	def process_overtime_slip(self):
+		overtime_components = self.get_overtime_component_amounts()
+
+		precision = frappe.db.get_single_value("System Settings", "currency_precision") or 2
+		for component, total_amount in overtime_components.items():
+			self.create_additional_salary(component, total_amount, precision)
+
+	def create_additional_salary(self, salary_component, total_amount, precision=None):
+		if total_amount > 0:
+			additional_salary = frappe.get_doc(
+				{
+					"doctype": "Additional Salary",
+					"company": self.company,
+					"employee": self.employee,
+					"salary_component": salary_component,
+					"amount": flt(total_amount, precision),
+					"payroll_date": self.end_date,
+					"overwrite_salary_structure_amount": 0,
+					"ref_doctype": "Overtime Slip",
+					"ref_docname": self.name,
+				}
+			)
+			additional_salary.submit()
+
+	def get_overtime_component_amounts(self):
+		"""
+		Get amount for each overtime detail child item, sum and group amounts by salary component for additional salary creation
+		"""
+		if not self.overtime_details:
+			return {}
+
+		unique_overtime_types = {detail.overtime_type for detail in self.overtime_details}
+
+		self.overtime_types = self._bulk_load_overtime_types(unique_overtime_types)
+		holiday_date_map = self.get_holiday_map()
+		overtime_components = {}
+
+		for overtime_detail in self.overtime_details:
+			overtime_type = overtime_detail.overtime_type
+			# calculate hourly rate separately for each overtime log since standard working hours may vary
+			applicable_hourly_rate = self._get_applicable_hourly_rate(
+				overtime_type, overtime_detail.get("standard_working_hours")
+			)
+
+			overtime_amount = self.calculate_overtime_amount(
+				overtime_type,
+				applicable_hourly_rate,
+				overtime_detail.overtime_duration,
+				overtime_detail.date,
+				holiday_date_map,
+			)
+
+			salary_component = self.overtime_types[overtime_type]["overtime_salary_component"]
+			overtime_components[salary_component] = (
+				overtime_components.get(salary_component, 0) + overtime_amount
+			)
+
+		return overtime_components
+
+	def _bulk_load_overtime_types(self, overtime_type_names):
+		"""
+		Load all overtime type details in bulk
+		"""
+		if not overtime_type_names:
+			return {}
+
+		# Get all overtime types details
+		overtime_types_data = frappe.get_all(
+			"Overtime Type",
+			filters={"name": ["in", list(overtime_type_names)]},
+			fields=[
+				"name",
+				"standard_multiplier",
+				"weekend_multiplier",
+				"public_holiday_multiplier",
+				"applicable_for_weekend",
+				"applicable_for_public_holiday",
+				"overtime_salary_component",
+				"overtime_calculation_method",
+				"hourly_rate",
+			],
+		)
+
+		overtime_types = {}
+		salary_component_based_types = []
+
+		for ot_data in overtime_types_data:
+			overtime_types[ot_data.name] = ot_data
+			if ot_data.overtime_calculation_method == "Salary Component Based":
+				salary_component_based_types.append(ot_data.name)
+
+		# Bulk load salary components for salary component based types
+		if salary_component_based_types:
+			salary_components_data = frappe.get_all(
+				"Overtime Salary Component",
+				filters={"parent": ["in", salary_component_based_types]},
+				fields=["parent", "salary_component"],
+			)
+
+			# Group by parent
+			components_by_parent = {}
+			for comp_data in salary_components_data:
+				if comp_data.parent not in components_by_parent:
+					components_by_parent[comp_data.parent] = []
+				components_by_parent[comp_data.parent].append(comp_data.salary_component)
+
+			for ot_type in salary_component_based_types:  # Add components to overtime types
+				overtime_types[ot_type]["components"] = components_by_parent.get(ot_type, [])
+
+		return overtime_types
+
+	def _get_applicable_hourly_rate(self, overtime_type, standard_working_hours=0):
+		overtime_details = self.overtime_types[overtime_type]
+		overtime_calculation_method = overtime_details["overtime_calculation_method"]
+
+		applicable_hourly_rate = 0.0
+		if overtime_calculation_method == "Fixed Hourly Rate":
+			applicable_hourly_rate = overtime_details.get("hourly_rate", 0.0)
+		elif overtime_calculation_method == "Salary Component Based":
+			applicable_hourly_rate = self._calculate_component_based_hourly_rate(
+				overtime_type, standard_working_hours
+			)
+		return applicable_hourly_rate
+
+	def _calculate_component_based_hourly_rate(self, overtime_type, standard_working_hours):
+		components = self.overtime_types[overtime_type]["components"] or []
+
+		if not hasattr(self, "_cached_salary_slip"):
+			salary_structure = get_assigned_salary_structure(self.employee, self.start_date)
+			self._cached_salary_slip = self._make_salary_slip(salary_structure)
+
+		if not components or not hasattr(self, "_cached_salary_slip"):
+			return 0.0
+
+		component_amount = sum(
+			data.amount
+			for data in self._cached_salary_slip.earnings
+			if data.salary_component in components and not data.get("additional_salary", None)
+		)
+		payment_days = max(self._cached_salary_slip.payment_days, 1)
+		applicable_daily_amount = component_amount / payment_days
+
+		return applicable_daily_amount / standard_working_hours
+
+	def _make_salary_slip(self, salary_structure):
+		from hrms.payroll.doctype.salary_structure.salary_structure import make_salary_slip
+
+		return make_salary_slip(
+			salary_structure,
+			employee=self.employee,
+			posting_date=self.start_date,
+		)
+
+	def calculate_overtime_amount(
+		self, overtime_type, applicable_hourly_rate, overtime_duration, overtime_date, holiday_date_map
+	):
+		"""
+		Calculate total amount for the given overtime detail child item based on its type and date.
+		"""
+		overtime_details = self.overtime_types.get(overtime_type)
+		if not overtime_details:
+			return 0.0
+
+		if applicable_hourly_rate <= 0:
+			return 0.0
+
+		overtime_date_str = cstr(overtime_date)
+		multiplier = overtime_details.get("standard_multiplier", 1)
+
+		holiday_info = holiday_date_map.get(overtime_date_str)
+		if holiday_info:
+			if overtime_details.get("applicable_for_weekend") and holiday_info.weekly_off:
+				multiplier = overtime_details.get("weekend_multiplier", multiplier)
+			elif overtime_details.get("applicable_for_public_holiday") and not holiday_info.weekly_off:
+				multiplier = overtime_details.get("public_holiday_multiplier", multiplier)
+
+		amount = overtime_duration * applicable_hourly_rate * multiplier
+		return amount
+
+	def get_holiday_map(self):
+		from erpnext.setup.doctype.employee.employee import get_holiday_list_for_employee
+
+		from hrms.utils.holiday_list import get_holiday_dates_between
+
+		holiday_list = get_holiday_list_for_employee(self.employee)
+		holiday_dates = get_holiday_dates_between(
+			holiday_list, self.start_date, self.end_date, select_weekly_off=True, as_dict=True
+		)
+
+		holiday_date_map = {}
+		for holiday_date in holiday_dates:
+			holiday_date_map[cstr(holiday_date.holiday_date)] = holiday_date
+
+		return holiday_date_map
+
+	def get_overtime_type_details(self, name):
+		details = frappe.get_value(
+			"Overtime Type",
+			filters={"name": name},
+			fieldname=[
+				"name",
+				"standard_multiplier",
+				"weekend_multiplier",
+				"public_holiday_multiplier",
+				"applicable_for_weekend",
+				"applicable_for_public_holiday",
+				"overtime_salary_component",
+				"overtime_calculation_method",
+				"hourly_rate",
+			],
+			as_dict=True,
+		)
+
+		components = []
+		if details.overtime_calculation_method == "Salary Component Based":
+			components = frappe.get_all(
+				"Overtime Salary Component", filters={"parent": name}, fields=["salary_component"]
+			)
+			components = [data.salary_component for data in components]
+		details["components"] = components
+
+		return details
+
+
+def filter_employees_for_overtime_slip_creation(start_date, end_date, employees, limit=None):
+	if not employees:
+		return []
+
+	if not isinstance(employees, list):
+		employees = json.loads(employees)
+
+	OvertimeSlip = frappe.qb.DocType("Overtime Slip")
+	Attendance = frappe.qb.DocType("Attendance")
+
+	# First, get employees with valid attendance records
+	employees_with_overtime_attendance = (
+		frappe.qb.from_(Attendance)
+		.select(Attendance.employee)
+		.distinct()
+		.where(
+			(Attendance.employee.isin(employees))
+			& (Attendance.attendance_date >= start_date)
+			& (Attendance.attendance_date <= end_date)
+			& (Attendance.docstatus == 1)  # Only submitted attendance
+			& (Attendance.status == "Present")  # Only present attendance
+			& (Attendance.overtime_type != "")
+			& (Attendance.overtime_type.isnotnull())
+		)
+	).run(pluck=True)
+
+	if not employees_with_overtime_attendance:
+		return []
+
+	# exclude employees who already have overtime slips for this period
+	employees_with_existing_overtime_slips = (
+		frappe.qb.from_(OvertimeSlip)
+		.select(OvertimeSlip.employee)
+		.distinct()
+		.where(
+			(OvertimeSlip.employee.isin(employees_with_overtime_attendance))
+			& (OvertimeSlip.docstatus != 2)
+			& (OvertimeSlip.start_date <= end_date)
+			& (OvertimeSlip.end_date >= start_date)
+		)
+	).run(pluck=True)
+
+	# Get eligible employees (those with overtime attendance but no existing slips)
+	eligible_employees = list(
+		set(employees_with_overtime_attendance) - set(employees_with_existing_overtime_slips)
+	)
+
+	return eligible_employees
+
+
+def create_overtime_slips_for_employees(employees, args):
+	count = 0
+	errors = []
+	for emp in employees:
+		emp_args = args.copy()
+		relieving_date = frappe.db.get_value("Employee", emp, "relieving_date")
+		relieving_date = getdate(relieving_date) if relieving_date else None
+		if relieving_date and relieving_date < getdate(emp_args.get("end_date")):
+			emp_args["start_date"] = getdate(emp_args.get("start_date"))
+			emp_args["end_date"] = relieving_date
+		emp_args.update({"doctype": "Overtime Slip", "employee": emp})
+		try:
+			frappe.get_doc(emp_args).get_emp_and_overtime_details()
+			count += 1
+		except Exception as e:
+			frappe.clear_last_message()
+			errors.append(_("Employee {0} : {1}").format(emp, str(e)))
+			frappe.log_error(frappe.get_traceback(), _("Overtime Slip Creation Error for {0}").format(emp))
+
+	if count:
+		frappe.msgprint(
+			_("Overtime Slip created for {0} employee(s)").format(count),
+			indicator="green",
+			title=_("Overtime Slips Created"),
+		)
+	if errors:
+		error_list_html = "".join(f"<li>{err}</li>" for err in errors)
+		frappe.msgprint(
+			title=_("Overtime Slip Creation Failed"),
+			msg=f"<ul>{error_list_html}</ul>",
+			indicator="red",
+		)
+
+	status = "Failed" if errors else "Draft"
+	frappe.get_doc("Payroll Entry", args.get("payroll_entry")).db_set({"status": status})
+	frappe.publish_realtime("completed_overtime_slip_creation", user=frappe.session.user)
+
+
+def submit_overtime_slips_for_employees(overtime_slips, payroll_entry):
+	count = 0
+	errors = []
+	for overtime_slip in overtime_slips:
+		try:
+			doc = frappe.get_doc("Overtime Slip", overtime_slip)
+			doc.submitted_via_payroll_entry = 1
+			doc.submit()
+			count += 1
+		except Exception as e:
+			frappe.clear_last_message()
+			errors.append(_("{0} : {1}").format(overtime_slip, str(e)))
+			frappe.log_error(
+				frappe.get_traceback(), _("Overtime Slip Submission Error for {0}").format(overtime_slip)
+			)
+	if count:
+		frappe.msgprint(
+			_("Overtime Slips submitted for {0} employee(s)").format(count),
+			indicator="green",
+			title=_("Overtime Slip Submitted"),
+		)
+	if errors:
+		error_list_html = "".join(f"<li>{err}</li>" for err in errors)
+		frappe.msgprint(
+			title=_("Overtime Slip Submission Failed"),
+			msg=_(f"<ul>{error_list_html}</ul>"),
+			indicator="red",
+		)
+
+	status = "Failed" if errors else "Draft"
+	payroll_entry = frappe.get_doc("Payroll Entry", payroll_entry).db_set({"status": status})
+	frappe.publish_realtime("completed_overtime_slip_submission", user=frappe.session.user)

--- a/hrms/hr/doctype/overtime_slip/test_overtime_slip.py
+++ b/hrms/hr/doctype/overtime_slip/test_overtime_slip.py
@@ -1,0 +1,302 @@
+# Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+import frappe
+from frappe.utils import add_days, flt, get_first_day, getdate, nowdate, today
+
+from erpnext.setup.doctype.employee.test_employee import make_employee
+
+from hrms.hr.doctype.employee_checkin.test_employee_checkin import make_checkin
+from hrms.hr.doctype.overtime_type.test_overtime_type import create_overtime_type
+from hrms.hr.doctype.shift_type.test_shift_type import make_shift_assignment, setup_shift_type
+from hrms.payroll.doctype.salary_slip.test_salary_slip import make_earning_salary_component
+from hrms.payroll.doctype.salary_structure.test_salary_structure import make_salary_structure
+from hrms.tests.utils import HRMSTestSuite
+
+
+class TestOvertimeSlip(HRMSTestSuite):
+	def test_overtime_calculation_and_additional_salary_creation(self):
+		from hrms.payroll.doctype.salary_structure.salary_structure import make_salary_slip
+
+		employee = make_employee("test_overtime_slip_salary@example.com", company="_Test Company")
+		salary_structure = make_salary_structure(
+			"Test Overtime Salary Slip", "Monthly", employee=employee, company="_Test Company"
+		)
+
+		overtime_type, overtime_slip, total_overtime_hours = setup_overtime(employee)
+
+		# Verify overtime details match attendance records
+		attendance_records = frappe.get_all(
+			"Attendance",
+			filters={"employee": employee, "status": "Present"},
+			fields=["name", "actual_overtime_duration", "overtime_type", "attendance_date"],
+		)
+		records = {rec.name: rec for rec in attendance_records}
+
+		for detail in overtime_slip.overtime_details:
+			self.assertIn(detail.reference_document, records)
+			self.assertEqual(
+				detail.overtime_duration, records[detail.reference_document].actual_overtime_duration
+			)
+			self.assertEqual(str(detail.date), str(records[detail.reference_document].attendance_date))
+
+		# Create salary slip and calculate expected overtime amount
+		salary_slip = make_salary_slip(
+			source_name=salary_structure.name,
+			employee=employee,
+			posting_date=overtime_slip.start_date,
+		)
+
+		standard_working_hours = overtime_slip.overtime_details[0].standard_working_hours
+		applicable_amount = sum(
+			data.amount
+			for data in salary_slip.earnings
+			if data.salary_component == "Basic Salary" and not data.get("additional_salary")
+		)
+		daily_wages = applicable_amount / salary_slip.payment_days
+		hourly_rate = daily_wages / standard_working_hours
+		expected_overtime_amount = hourly_rate * total_overtime_hours * overtime_type.standard_multiplier
+
+		actual_overtime_amount = frappe.db.get_value(
+			"Additional Salary", {"ref_docname": overtime_slip.name}, "amount"
+		)
+		self.assertEqual(flt(expected_overtime_amount, 2), actual_overtime_amount)
+
+	def test_overtime_calculation_for_fixed_hourly_rate(self):
+		employee = make_employee("test_overtime_slip_fixed@example.com", company="_Test Company")
+		make_salary_structure(
+			"Test Overtime Salary Slip", "Monthly", employee=employee, company="_Test Company"
+		)
+
+		overtime_type, overtime_slip, total_overtime_hours = setup_overtime(employee, "Fixed Hourly Rate")
+		expected_overtime_amount = (
+			overtime_type.hourly_rate * total_overtime_hours * overtime_type.standard_multiplier
+		)
+
+		actual_overtime_amount = frappe.db.get_value(
+			"Additional Salary", {"ref_docname": overtime_slip.name}, "amount"
+		)
+
+		self.assertEqual(flt(expected_overtime_amount, 2), flt(actual_overtime_amount, 2))
+
+	def test_overtime_slip_creation_via_payroll_entry(self):
+		"""Test creation of overtime slips via payroll entry."""
+		from hrms.payroll.doctype.payroll_entry.payroll_entry import get_start_end_dates
+		from hrms.payroll.doctype.payroll_entry.test_payroll_entry import get_payroll_entry
+
+		date = getdate()
+		month_start_date = get_first_day(date)
+
+		company = frappe.get_doc("Company", "_Test Company")
+		make_earning_salary_component(setup=True, company_list=["_Test Company"])
+		employee = make_employee("test_overtime_slip_01@example.com", company="_Test Company")
+		overtime_type = create_overtime_type(overtime_calculation_method="Fixed Hourly Rate")
+		shift_type = setup_shift_type(
+			company="_Test Company",
+			shift_type="_Test Overtime Shift",
+			allow_overtime=1,
+			overtime_type=overtime_type.name,
+			last_sync_of_checkin=f"{add_days(date, 10)} 15:00:00",
+			process_attendance_after=add_days(month_start_date, -1),
+			mark_auto_attendance_on_holidays=1,
+		)
+		frappe.db.set_single_value("Payroll Settings", "create_overtime_slip", 1)
+
+		make_salary_structure(
+			"Test Overtime Salary Slip", "Monthly", employee=employee, company="_Test Company"
+		)
+		make_shift_assignment(
+			shift_type=shift_type.name, employee=employee, start_date=add_days(month_start_date, -1)
+		)
+		create_checkin_records_for_overtime(employee)
+		shift_type.process_auto_attendance()
+
+		dates = get_start_end_dates("Monthly", nowdate())
+		payroll_entry = get_payroll_entry(
+			start_date=dates.start_date,
+			end_date=dates.end_date,
+			payable_account=company.default_payroll_payable_account,
+			currency=company.default_currency,
+			company=company.name,
+			cost_center="Main - _TC",
+		)
+
+		payroll_entry.create_overtime_slips()
+		payroll_entry.submit_overtime_slips()
+
+		overtime_slip = frappe.db.exists(
+			"Overtime Slip",
+			{
+				"employee": employee,
+				"payroll_entry": payroll_entry.name,
+				"docstatus": 1,
+			},
+		)
+
+		self.assertTrue(overtime_slip)
+
+	def test_overtime_slip_creation_via_payroll_entry_mid_month_leaver(self):
+		"""OT slip `end_date` must be capped at `relieving_date` so the resulting Additional Salary `payroll_date` falls within the employee's employment window."""
+		from hrms.hr.doctype.overtime_slip.overtime_slip import create_overtime_slips_for_employees
+		from hrms.payroll.doctype.payroll_entry.payroll_entry import get_start_end_dates
+		from hrms.payroll.doctype.payroll_entry.test_payroll_entry import get_payroll_entry
+
+		date = getdate()
+		month_start_date = get_first_day(date)
+		relieving_date = add_days(month_start_date, 14)  # mid-month, day 15
+
+		company = frappe.get_doc("Company", "_Test Company")
+		make_earning_salary_component(setup=True, company_list=["_Test Company"])
+		employee = make_employee(
+			"test_overtime_slip_mid_leaver@example.com",
+			company="_Test Company",
+			relieving_date=relieving_date,
+			status="Left",
+		)
+		overtime_type = create_overtime_type(overtime_calculation_method="Fixed Hourly Rate")
+		shift_type = setup_shift_type(
+			company="_Test Company",
+			shift_type="_Test Overtime Shift Mid Leaver",
+			allow_overtime=1,
+			overtime_type=overtime_type.name,
+			last_sync_of_checkin=f"{add_days(date, 10)} 15:00:00",
+			process_attendance_after=add_days(month_start_date, -1),
+			mark_auto_attendance_on_holidays=1,
+		)
+		frappe.db.set_single_value("Payroll Settings", "create_overtime_slip", 1)
+
+		make_salary_structure(
+			"Test Overtime Salary Slip", "Monthly", employee=employee, company="_Test Company"
+		)
+		make_shift_assignment(
+			shift_type=shift_type.name, employee=employee, start_date=add_days(month_start_date, -1)
+		)
+		create_checkin_records_for_overtime(employee)
+		shift_type.process_auto_attendance()
+
+		dates = get_start_end_dates("Monthly", nowdate())
+		payroll_entry = get_payroll_entry(
+			start_date=dates.start_date,
+			end_date=dates.end_date,
+			payable_account=company.default_payroll_payable_account,
+			currency=company.default_currency,
+			company=company.name,
+			cost_center="Main - _TC",
+		)
+
+		payroll_entry.create_overtime_slips()
+
+		slip_name = frappe.db.get_value(
+			"Overtime Slip",
+			{"employee": employee, "payroll_entry": payroll_entry.name, "docstatus": 0},
+			"name",
+		)
+		self.assertTrue(slip_name, "Overtime Slip not created for mid-month leaver")
+
+		slip = frappe.get_doc("Overtime Slip", slip_name)
+		self.assertEqual(
+			getdate(slip.end_date),
+			getdate(relieving_date),
+			"end_date must be capped at relieving_date, not PE.end_date",
+		)
+
+		# submission must succeed as payroll_date = relieving_date is valid
+		slip.submit()
+		self.assertEqual(slip.docstatus, 1)
+
+		additional_salary = frappe.db.get_value(
+			"Additional Salary", {"ref_docname": slip.name}, "payroll_date"
+		)
+		self.assertEqual(
+			getdate(additional_salary),
+			getdate(relieving_date),
+			"Additional Salary payroll_date must equal relieving_date",
+		)
+
+		# creating slips from the client sends the payroll entry dates as strings,
+		# so the capped end_date must stay comparable with start_date in validate()
+		frappe.db.delete("Additional Salary", {"ref_docname": slip.name})
+		slip.cancel()
+		frappe.delete_doc("Overtime Slip", slip.name, force=True)
+
+		create_overtime_slips_for_employees(
+			[employee],
+			frappe._dict(
+				{
+					"posting_date": str(dates.end_date),
+					"start_date": str(dates.start_date),
+					"end_date": str(dates.end_date),
+					"company": "_Test Company",
+					"currency": company.default_currency,
+					"payroll_entry": payroll_entry.name,
+				}
+			),
+		)
+
+		slip_name = frappe.db.get_value("Overtime Slip", {"employee": employee}, "name")
+		self.assertTrue(slip_name, "Overtime Slip not created when dates are passed as strings")
+		self.assertEqual(
+			getdate(frappe.db.get_value("Overtime Slip", slip_name, "end_date")),
+			getdate(relieving_date),
+			"end_date must be capped at relieving_date when dates are passed as strings",
+		)
+
+
+def create_overtime_slip(employee):
+	date = getdate()
+	month_start_date = get_first_day(date)
+	slip = frappe.new_doc("Overtime Slip")
+	slip.employee = employee
+	slip.posting_date = today()
+	slip.start_date = month_start_date
+	slip.end_date = add_days(month_start_date, 2)
+	slip.get_emp_and_overtime_details()
+	return slip
+
+
+def create_checkin_records_for_overtime(employee):
+	date = getdate()
+	month_start_date = get_first_day(date)
+	checkin_times = [
+		(f"{month_start_date} 7:00:00", "IN"),
+		(f"{month_start_date} 13:00:00", "OUT"),
+		(f"{add_days(month_start_date, 1)} 7:00:00", "IN"),
+		(f"{add_days(month_start_date, 1)} 13:00:00", "OUT"),
+	]
+	for time, log_type in checkin_times:
+		make_checkin(employee, time=time, log_type=log_type)
+
+
+def setup_overtime(employee, overtime_calculation_method="Salary Component Based"):
+	overtime_type = create_overtime_type(overtime_calculation_method=overtime_calculation_method)
+
+	date = getdate()
+	month_start_date = get_first_day(date)
+	shift_type = setup_shift_type(
+		company="_Test Company",
+		shift_type="_Test Overtime Shift",
+		allow_overtime=1,
+		overtime_type=overtime_type.name,
+		last_sync_of_checkin=f"{add_days(date, 10)} 15:00:00",
+		process_attendance_after=add_days(month_start_date, -1),
+		mark_auto_attendance_on_holidays=1,
+	)
+
+	make_shift_assignment(
+		shift_type=shift_type.name, employee=employee, start_date=add_days(month_start_date, -1)
+	)
+	create_checkin_records_for_overtime(employee)
+	shift_type.process_auto_attendance()
+
+	slip = create_overtime_slip(employee)
+	slip.submit()
+
+	overtime_details = frappe.get_all(
+		"Overtime Details",
+		filters={"parent": slip.name},
+		fields=["overtime_type", "overtime_duration", "date", "standard_working_hours"],
+	)
+
+	total_overtime_hours = sum(detail["overtime_duration"] for detail in overtime_details)
+
+	return overtime_type, slip, total_overtime_hours

--- a/hrms/hr/doctype/staffing_plan/staffing_plan.py
+++ b/hrms/hr/doctype/staffing_plan/staffing_plan.py
@@ -1,10 +1,12 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
+import datetime
 
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.query_builder.functions import Sum
 from frappe.utils import cint, flt, getdate, nowdate
 from frappe.utils.nestedset import get_descendants_of
 
@@ -18,6 +20,25 @@ class ParentCompanyError(frappe.ValidationError):
 
 
 class StaffingPlan(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from hrms.hr.doctype.staffing_plan_detail.staffing_plan_detail import StaffingPlanDetail
+
+		amended_from: DF.Link | None
+		company: DF.Link
+		department: DF.Link | None
+		from_date: DF.Date
+		staffing_details: DF.Table[StaffingPlanDetail]
+		to_date: DF.Date
+		total_estimated_budget: DF.Currency
+	# end: auto-generated types
+
 	def validate(self):
 		self.validate_period()
 		self.validate_details()
@@ -39,11 +60,10 @@ class StaffingPlan(Document):
 
 		for detail in self.get("staffing_details"):
 			# Set readonly fields
-			self.set_number_of_positions(detail)
 			designation_counts = get_designation_counts(detail.designation, self.company)
 			detail.current_count = designation_counts["employee_count"]
 			detail.current_openings = designation_counts["job_openings"]
-
+			self.set_number_of_positions(detail)
 			detail.total_estimated_cost = 0
 			if detail.number_of_positions > 0:
 				if detail.vacancies and detail.estimated_cost_per_position:
@@ -59,14 +79,21 @@ class StaffingPlan(Document):
 	def validate_overlap(self, staffing_plan_detail):
 		# Validate if any submitted Staffing Plan exist for any Designations in this plan
 		# and spd.vacancies>0 ?
-		overlap = frappe.db.sql(
-			"""select spd.parent
-			from `tabStaffing Plan Detail` spd join `tabStaffing Plan` sp on spd.parent=sp.name
-			where spd.designation=%s and sp.docstatus=1
-			and sp.to_date >= %s and sp.from_date <= %s and sp.company = %s
-		""",
-			(staffing_plan_detail.designation, self.from_date, self.to_date, self.company),
-		)
+		spd = frappe.qb.DocType("Staffing Plan Detail")
+		sp = frappe.qb.DocType("Staffing Plan")
+		overlap = (
+			frappe.qb.from_(spd)
+			.join(sp)
+			.on(spd.parent == sp.name)
+			.select(spd.parent)
+			.where(
+				(spd.designation == staffing_plan_detail.designation)
+				& (sp.docstatus == 1)
+				& (sp.to_date >= self.from_date)
+				& (sp.from_date <= self.to_date)
+				& (sp.company == self.company)
+			)
+		).run()
 		if overlap and overlap[0][0]:
 			frappe.throw(
 				_("Staffing Plan {0} already exist for designation {1}").format(
@@ -106,16 +133,29 @@ class StaffingPlan(Document):
 
 		# Get vacanices already planned for all companies down the hierarchy of Parent Company
 		lft, rgt = frappe.get_cached_value("Company", parent_company, ["lft", "rgt"])
-		all_sibling_details = frappe.db.sql(
-			"""select sum(spd.vacancies) as vacancies,
-			sum(spd.total_estimated_cost) as total_estimated_cost
-			from `tabStaffing Plan Detail` spd join `tabStaffing Plan` sp on spd.parent=sp.name
-			where spd.designation=%s and sp.docstatus=1
-			and sp.to_date >= %s and sp.from_date <=%s
-			and sp.company in (select name from tabCompany where lft > %s and rgt < %s)
-		""",
-			(staffing_plan_detail.designation, self.from_date, self.to_date, lft, rgt),
-			as_dict=1,
+		spd = frappe.qb.DocType("Staffing Plan Detail")
+		sp = frappe.qb.DocType("Staffing Plan")
+		company = frappe.qb.DocType("Company")
+		all_sibling_details = (
+			frappe.qb.from_(spd)
+			.join(sp)
+			.on(spd.parent == sp.name)
+			.select(
+				Sum(spd.vacancies).as_("vacancies"),
+				Sum(spd.total_estimated_cost).as_("total_estimated_cost"),
+			)
+			.where(
+				(spd.designation == staffing_plan_detail.designation)
+				& (sp.docstatus == 1)
+				& (sp.to_date >= self.from_date)
+				& (sp.from_date <= self.to_date)
+				& sp.company.isin(
+					frappe.qb.from_(company)
+					.select(company.name)
+					.where((company.lft > lft) & (company.rgt < rgt))
+				)
+			)
+			.run(as_dict=1)
 		)[0]
 
 		if (
@@ -141,16 +181,29 @@ class StaffingPlan(Document):
 
 	def validate_with_subsidiary_plans(self, staffing_plan_detail):
 		# Valdate this plan with all child company plan
-		children_details = frappe.db.sql(
-			"""select sum(spd.vacancies) as vacancies,
-			sum(spd.total_estimated_cost) as total_estimated_cost
-			from `tabStaffing Plan Detail` spd join `tabStaffing Plan` sp on spd.parent=sp.name
-			where spd.designation=%s and sp.docstatus=1
-			and sp.to_date >= %s and sp.from_date <=%s
-			and sp.company in (select name from tabCompany where parent_company = %s)
-		""",
-			(staffing_plan_detail.designation, self.from_date, self.to_date, self.company),
-			as_dict=1,
+		spd = frappe.qb.DocType("Staffing Plan Detail")
+		sp = frappe.qb.DocType("Staffing Plan")
+		company = frappe.qb.DocType("Company")
+		children_details = (
+			frappe.qb.from_(spd)
+			.join(sp)
+			.on(spd.parent == sp.name)
+			.select(
+				Sum(spd.vacancies).as_("vacancies"),
+				Sum(spd.total_estimated_cost).as_("total_estimated_cost"),
+			)
+			.where(
+				(spd.designation == staffing_plan_detail.designation)
+				& (sp.docstatus == 1)
+				& (sp.to_date >= self.from_date)
+				& (sp.from_date <= self.to_date)
+				& sp.company.isin(
+					frappe.qb.from_(company)
+					.select(company.name)
+					.where(company.parent_company == self.company)
+				)
+			)
+			.run(as_dict=1)
 		)[0]
 
 		if (
@@ -171,7 +224,7 @@ class StaffingPlan(Document):
 			)
 
 	@frappe.whitelist()
-	def set_job_requisitions(self, job_reqs):
+	def set_job_requisitions(self, job_reqs: list[str]) -> Document:
 		if job_reqs:
 			requisitions = frappe.db.get_list(
 				"Job Requisition",
@@ -181,12 +234,14 @@ class StaffingPlan(Document):
 
 			self.staffing_details = []
 			for req in requisitions:
+				current_count = get_designation_counts(req.designation, self.company)["employee_count"]
 				self.append(
 					"staffing_details",
 					{
 						"designation": req.designation,
 						"vacancies": req.no_of_positions,
 						"estimated_cost_per_position": req.expected_compensation,
+						"number_of_positions": cint(current_count) + cint(req.no_of_positions),
 					},
 				)
 
@@ -194,7 +249,7 @@ class StaffingPlan(Document):
 
 
 @frappe.whitelist()
-def get_designation_counts(designation, company, job_opening=None):
+def get_designation_counts(designation: str, company: str, job_opening: str | None = None) -> dict | bool:
 	if not designation:
 		return False
 
@@ -215,7 +270,14 @@ def get_designation_counts(designation, company, job_opening=None):
 
 
 @frappe.whitelist()
-def get_active_staffing_plan_details(company, designation, from_date=None, to_date=None):
+def get_active_staffing_plan_details(
+	company: str,
+	designation: str,
+	from_date: str | datetime.date | None = None,
+	to_date: str | datetime.date | None = None,
+) -> list[dict] | None:
+	frappe.has_permission("Staffing Plan", "read", throw=True)
+
 	if from_date is None:
 		from_date = getdate(nowdate())
 	if to_date is None:
@@ -223,14 +285,21 @@ def get_active_staffing_plan_details(company, designation, from_date=None, to_da
 	if not company or not designation:
 		frappe.throw(_("Please select Company and Designation"))
 
-	staffing_plan = frappe.db.sql(
-		"""
-		select sp.name, spd.vacancies, spd.total_estimated_cost
-		from `tabStaffing Plan Detail` spd join `tabStaffing Plan` sp on spd.parent=sp.name
-		where company=%s and spd.designation=%s and sp.docstatus=1
-		and to_date >= %s and from_date <= %s """,
-		(company, designation, from_date, to_date),
-		as_dict=1,
+	spd = frappe.qb.DocType("Staffing Plan Detail")
+	sp = frappe.qb.DocType("Staffing Plan")
+	staffing_plan = (
+		frappe.qb.from_(spd)
+		.join(sp)
+		.on(spd.parent == sp.name)
+		.select(sp.name, spd.vacancies, spd.total_estimated_cost)
+		.where(
+			(sp.company == company)
+			& (spd.designation == designation)
+			& (sp.docstatus == 1)
+			& (sp.to_date >= from_date)
+			& (sp.from_date <= to_date)
+		)
+		.run(as_dict=1)
 	)
 
 	if not staffing_plan:

--- a/hrms/hr/doctype/training_result/training_result.py
+++ b/hrms/hr/doctype/training_result/training_result.py
@@ -10,6 +10,22 @@ from erpnext.setup.doctype.employee.employee import get_employee_emails
 
 
 class TrainingResult(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from hrms.hr.doctype.training_result_employee.training_result_employee import TrainingResultEmployee
+
+		amended_from: DF.Link | None
+		employee_emails: DF.SmallText | None
+		employees: DF.Table[TrainingResultEmployee]
+		training_event: DF.Link
+	# end: auto-generated types
+
 	def validate(self):
 		training_event = frappe.get_doc("Training Event", self.training_event)
 		if training_event.docstatus != 1:
@@ -30,5 +46,6 @@ class TrainingResult(Document):
 
 
 @frappe.whitelist()
-def get_employees(training_event):
+def get_employees(training_event: str):
+	frappe.has_permission("Training Event", "read", training_event, throw=True)
 	return frappe.get_doc("Training Event", training_event).employees

--- a/hrms/hr/doctype/vehicle_log/test_vehicle_log.py
+++ b/hrms/hr/doctype/vehicle_log/test_vehicle_log.py
@@ -1,28 +1,34 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
+import json
+
 import frappe
-from frappe.tests import IntegrationTestCase
+from frappe.desk.form.linked_with import cancel_all_linked_docs, get_submitted_linked_docs
 from frappe.utils import cstr, flt, nowdate, random_string
 
 from erpnext.setup.doctype.employee.test_employee import make_employee
 
-from hrms.hr.doctype.vehicle_log.vehicle_log import make_expense_claim
+from hrms.hr.doctype.vehicle_log.vehicle_log import (
+	get_draft_expense_claim_cancellation_actions,
+	get_draft_expense_claims,
+	make_expense_claim,
+)
+from hrms.tests.utils import HRMSTestSuite
 
 
-class TestVehicleLog(IntegrationTestCase):
+class TestVehicleLog(HRMSTestSuite):
 	def setUp(self):
-		employee_id = frappe.db.sql("""select name from `tabEmployee` where name='testdriver@example.com'""")
+		employee = frappe.qb.DocType("Employee")
+		employee_id = (
+			frappe.qb.from_(employee).select(employee.name).where(employee.name == "testdriver@example.com")
+		).run()
 		self.employee_id = employee_id[0][0] if employee_id else None
 
 		if not self.employee_id:
 			self.employee_id = make_employee("testdriver@example.com", company="_Test Company")
 
 		self.license_plate = get_vehicle(self.employee_id)
-
-	def tearDown(self):
-		frappe.delete_doc("Vehicle", self.license_plate, force=1)
-		frappe.delete_doc("Employee", self.employee_id, force=1)
 
 	def test_make_vehicle_log_and_syncing_of_odometer_value(self):
 		vehicle_log = make_vehicle_log(self.license_plate, self.employee_id)
@@ -51,7 +57,6 @@ class TestVehicleLog(IntegrationTestCase):
 		self.assertEqual(fuel_expense, 50 * 500)
 
 		vehicle_log.cancel()
-		frappe.delete_doc("Expense Claim", expense_claim.name)
 		frappe.delete_doc("Vehicle Log", vehicle_log.name)
 
 	def test_vehicle_log_with_service_expenses(self):
@@ -62,8 +67,200 @@ class TestVehicleLog(IntegrationTestCase):
 		self.assertEqual(expenses, 27000)
 
 		vehicle_log.cancel()
-		frappe.delete_doc("Expense Claim", expense_claim.name)
 		frappe.delete_doc("Vehicle Log", vehicle_log.name)
+
+	def test_cancel_vehicle_log_unlinks_draft_expense_claim(self):
+		vehicle_log = make_vehicle_log(self.license_plate, self.employee_id)
+		currency, cost_center = frappe.db.get_value(
+			"Company", "_Test Company", ["default_currency", "cost_center"]
+		)
+		expense_claim = frappe.get_doc(
+			{
+				"doctype": "Expense Claim",
+				"employee": self.employee_id,
+				"company": "_Test Company",
+				"currency": currency,
+				"exchange_rate": 1,
+				"approval_status": "Approved",
+				"payable_account": frappe.db.get_value("Company", "_Test Company", "default_payable_account"),
+				"vehicle_log": vehicle_log.name,
+				"expenses": [
+					{
+						"expense_type": "Travel",
+						"default_account": "Travel Expenses - _TC",
+						"currency": currency,
+						"amount": 100,
+						"sanctioned_amount": 100,
+						"cost_center": cost_center,
+					}
+				],
+			}
+		).insert()
+
+		self.assertIn(expense_claim.name, get_draft_expense_claims(vehicle_log.name))
+		self.assertEqual(
+			get_draft_expense_claim_cancellation_actions(vehicle_log.name),
+			[{"name": expense_claim.name, "action": "unlink"}],
+		)
+
+		vehicle_log.reload()
+		vehicle_log.cancel()
+		expense_claim.reload()
+
+		self.assertEqual(vehicle_log.docstatus, 2)
+		self.assertIsNone(expense_claim.vehicle_log)
+		self.assertNotIn(expense_claim.name, get_draft_expense_claims(vehicle_log.name))
+		# non-Vehicle-Log expense rows remain intact
+		self.assertEqual(len(expense_claim.expenses), 1)
+		self.assertEqual(expense_claim.expenses[0].expense_type, "Travel")
+
+		expense_claim.submit()
+
+		expense_claim.cancel()
+		frappe.delete_doc("Vehicle Log", vehicle_log.name)
+
+	def test_cancel_vehicle_log_deletes_claim_with_only_vehicle_log_expenses(self):
+		vehicle_log = make_vehicle_log(self.license_plate, self.employee_id)
+		currency, cost_center = frappe.db.get_value(
+			"Company", "_Test Company", ["default_currency", "cost_center"]
+		)
+
+		expense_claim = frappe.get_doc(
+			{
+				"doctype": "Expense Claim",
+				"employee": self.employee_id,
+				"company": "_Test Company",
+				"currency": currency,
+				"exchange_rate": 1,
+				"approval_status": "Approved",
+				"payable_account": frappe.db.get_value("Company", "_Test Company", "default_payable_account"),
+				"vehicle_log": vehicle_log.name,
+				"expenses": [
+					{
+						"expense_date": nowdate(),
+						"expense_type": "Travel",
+						"default_account": "Travel Expenses - _TC",
+						"currency": currency,
+						"description": "Vehicle Expenses",
+						"amount": 25000,
+						"sanctioned_amount": 25000,
+						"cost_center": cost_center,
+					}
+				],
+			}
+		).insert()
+
+		self.assertIn(expense_claim.name, get_draft_expense_claims(vehicle_log.name))
+		self.assertEqual(
+			get_draft_expense_claim_cancellation_actions(vehicle_log.name),
+			[{"name": expense_claim.name, "action": "delete"}],
+		)
+
+		vehicle_log.reload()
+		vehicle_log.cancel()
+
+		self.assertFalse(frappe.db.exists("Expense Claim", expense_claim.name))
+		frappe.delete_doc("Vehicle Log", vehicle_log.name)
+
+	def test_cancel_vehicle_log_removes_only_vehicle_log_rows_from_mixed_claim(self):
+		vehicle_log = make_vehicle_log(self.license_plate, self.employee_id)
+		currency, cost_center = frappe.db.get_value(
+			"Company", "_Test Company", ["default_currency", "cost_center"]
+		)
+
+		expense_claim = frappe.get_doc(
+			{
+				"doctype": "Expense Claim",
+				"employee": self.employee_id,
+				"company": "_Test Company",
+				"currency": currency,
+				"exchange_rate": 1,
+				"approval_status": "Approved",
+				"payable_account": frappe.db.get_value("Company", "_Test Company", "default_payable_account"),
+				"vehicle_log": vehicle_log.name,
+				"expenses": [
+					{
+						"expense_date": nowdate(),
+						"expense_type": "Travel",
+						"default_account": "Travel Expenses - _TC",
+						"currency": currency,
+						"description": "Vehicle Expenses",
+						"amount": 25000,
+						"sanctioned_amount": 25000,
+						"cost_center": cost_center,
+					},
+					{
+						"expense_date": nowdate(),
+						"expense_type": "Travel",
+						"default_account": "Travel Expenses - _TC",
+						"currency": currency,
+						"description": "Accident Repair",
+						"amount": 5000,
+						"sanctioned_amount": 5000,
+						"cost_center": cost_center,
+					},
+				],
+			}
+		).insert()
+
+		self.assertIn(expense_claim.name, get_draft_expense_claims(vehicle_log.name))
+		self.assertEqual(len(expense_claim.expenses), 2)
+		self.assertEqual(
+			get_draft_expense_claim_cancellation_actions(vehicle_log.name),
+			[{"name": expense_claim.name, "action": "unlink"}],
+		)
+
+		vehicle_log.reload()
+		vehicle_log.cancel()
+
+		expense_claim.reload()
+		self.assertEqual(len(expense_claim.expenses), 1)
+		self.assertEqual(expense_claim.expenses[0].description, "Accident Repair")
+		self.assertIsNone(expense_claim.vehicle_log)
+
+		expense_claim.submit()
+		expense_claim.cancel()
+		frappe.delete_doc("Vehicle Log", vehicle_log.name)
+
+	def test_cancel_vehicle_log_with_submitted_expense_claim_uses_linked_doc_cancellation(self):
+		vehicle_log = make_vehicle_log(self.license_plate, self.employee_id)
+		currency, cost_center = frappe.db.get_value(
+			"Company", "_Test Company", ["default_currency", "cost_center"]
+		)
+		expense_claim = frappe.get_doc(
+			{
+				"doctype": "Expense Claim",
+				"employee": self.employee_id,
+				"company": "_Test Company",
+				"currency": currency,
+				"exchange_rate": 1,
+				"approval_status": "Approved",
+				"payable_account": frappe.db.get_value("Company", "_Test Company", "default_payable_account"),
+				"vehicle_log": vehicle_log.name,
+				"expenses": [
+					{
+						"expense_type": "Travel",
+						"default_account": "Travel Expenses - _TC",
+						"currency": currency,
+						"amount": 100,
+						"sanctioned_amount": 100,
+						"cost_center": cost_center,
+					}
+				],
+			}
+		).insert()
+		expense_claim.submit()
+
+		linked_docs = get_submitted_linked_docs("Vehicle Log", vehicle_log.name)["docs"]
+		self.assertIn({"doctype": "Expense Claim", "name": expense_claim.name, "docstatus": 1}, linked_docs)
+
+		cancel_all_linked_docs(json.dumps(linked_docs))
+		expense_claim.reload()
+		self.assertEqual(expense_claim.docstatus, 2)
+
+		vehicle_log.reload()
+		vehicle_log.cancel()
+		self.assertEqual(vehicle_log.docstatus, 2)
 
 
 def get_vehicle(employee_id):

--- a/hrms/hr/doctype/vehicle_log/vehicle_log.js
+++ b/hrms/hr/doctype/vehicle_log/vehicle_log.js
@@ -24,6 +24,35 @@ frappe.ui.form.on("Vehicle Log", {
 		}
 	},
 
+	before_cancel: function (frm) {
+		return new Promise((resolve, reject) => {
+			frappe.call({
+				method: "hrms.hr.doctype.vehicle_log.vehicle_log.get_draft_expense_claim_cancellation_actions",
+				args: {
+					vehicle_log: frm.doc.name,
+				},
+				callback: function (r) {
+					const expense_claims = r.message || [];
+					if (!expense_claims.length) {
+						resolve();
+						return;
+					}
+
+					frappe.confirm(
+						get_expense_claim_cancellation_message(expense_claims, frm.doc.name),
+						() => resolve(),
+						() => reject(),
+						__("Yes"),
+						__("No"),
+					);
+				},
+				error: function (err) {
+					reject(err);
+				},
+			});
+		});
+	},
+
 	expense_claim: function (frm) {
 		frappe.call({
 			method: "hrms.hr.doctype.vehicle_log.vehicle_log.make_expense_claim",
@@ -37,3 +66,24 @@ frappe.ui.form.on("Vehicle Log", {
 		});
 	},
 });
+
+function get_expense_claim_cancellation_message(expense_claims, vehicle_log) {
+	const expense_claim = expense_claims[0];
+	const expense_claim_link = frappe.utils.get_form_link(
+		"Expense Claim",
+		expense_claim.name,
+		true,
+	);
+
+	if (expense_claim.action === "delete") {
+		return __(
+			"Cancelling Vehicle Log {0} will delete draft Expense Claim {1} because it only contains Vehicle Expenses.<br><br>Do you want to continue?",
+			[vehicle_log.bold(), expense_claim_link],
+		);
+	}
+
+	return __(
+		"Cancelling Vehicle Log {0} will update draft Expense Claim {1}.<br><br>Vehicle Expenses rows will be removed. Other expenses will remain.<br><br>Do you want to continue?",
+		[vehicle_log.bold(), expense_claim_link],
+	);
+}

--- a/hrms/hr/doctype/vehicle_log/vehicle_log.py
+++ b/hrms/hr/doctype/vehicle_log/vehicle_log.py
@@ -9,6 +9,32 @@ from frappe.utils import flt
 
 
 class VehicleLog(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from hrms.hr.doctype.vehicle_service.vehicle_service import VehicleService
+
+		amended_from: DF.Link | None
+		date: DF.Date
+		employee: DF.Link
+		fuel_qty: DF.Float
+		invoice: DF.Data | None
+		last_odometer: DF.Int
+		license_plate: DF.Link
+		make: DF.ReadOnly | None
+		model: DF.ReadOnly | None
+		naming_series: DF.Literal["HR-VLOG-.YYYY.-"]
+		odometer: DF.Int
+		price: DF.Currency
+		service_detail: DF.Table[VehicleService]
+		supplier: DF.Link | None
+	# end: auto-generated types
+
 	def validate(self):
 		if flt(self.odometer) < flt(self.last_odometer):
 			frappe.throw(
@@ -20,6 +46,20 @@ class VehicleLog(Document):
 	def on_submit(self):
 		frappe.db.set_value("Vehicle", self.license_plate, "last_odometer", self.odometer)
 
+	def before_cancel(self):
+		for expense_claim_name in _get_draft_expense_claims(self.name):
+			expense_claim = frappe.get_doc("Expense Claim", expense_claim_name)
+
+			if _has_non_vehicle_log_expenses(expense_claim):
+				for row in list(expense_claim.expenses):
+					if row.description == _("Vehicle Expenses"):
+						expense_claim.remove(row)
+
+				expense_claim.vehicle_log = None
+				expense_claim.save()
+			else:
+				expense_claim.delete()
+
 	def on_cancel(self):
 		distance_travelled = self.odometer - self.last_odometer
 		if distance_travelled > 0:
@@ -30,14 +70,15 @@ class VehicleLog(Document):
 
 
 @frappe.whitelist()
-def make_expense_claim(docname):
+def make_expense_claim(docname: str) -> dict:
+	frappe.has_permission("Vehicle Log", "read", docname, throw=True)
+
 	expense_claim = frappe.db.exists("Expense Claim", {"vehicle_log": docname})
 	if expense_claim:
 		frappe.throw(_("Expense Claim {0} already exists for the Vehicle Log").format(expense_claim))
 
 	vehicle_log = frappe.get_doc("Vehicle Log", docname)
 	service_expense = sum([flt(d.expense_amount) for d in vehicle_log.service_detail])
-
 	refuelling_expense = flt(vehicle_log.price) * flt(vehicle_log.fuel_qty)
 	claim_amount = service_expense + refuelling_expense
 	if not claim_amount:
@@ -52,3 +93,44 @@ def make_expense_claim(docname):
 		{"expense_date": vehicle_log.date, "description": _("Vehicle Expenses"), "amount": claim_amount},
 	)
 	return exp_claim.as_dict()
+
+
+@frappe.whitelist()
+def get_draft_expense_claims(vehicle_log: str) -> list[str]:
+	frappe.has_permission("Vehicle Log", doc=vehicle_log, throw=True)
+
+	return _get_draft_expense_claims(vehicle_log)
+
+
+@frappe.whitelist()
+def get_draft_expense_claim_cancellation_actions(vehicle_log: str) -> list[dict[str, str]]:
+	frappe.has_permission("Vehicle Log", doc=vehicle_log, throw=True)
+
+	return [
+		{
+			"name": expense_claim.name,
+			"action": "unlink" if _has_non_vehicle_log_expenses(expense_claim) else "delete",
+		}
+		for expense_claim in _get_draft_expense_claim_docs(vehicle_log)
+	]
+
+
+def _get_draft_expense_claims(vehicle_log: str) -> list[str]:
+	return frappe.get_all(
+		"Expense Claim",
+		filters={"vehicle_log": vehicle_log, "docstatus": 0},
+		pluck="name",
+		order_by="creation asc",
+	)
+
+
+def _get_draft_expense_claim_docs(vehicle_log: str) -> list[Document]:
+	return [
+		frappe.get_doc("Expense Claim", expense_claim_name)
+		for expense_claim_name in _get_draft_expense_claims(vehicle_log)
+	]
+
+
+def _has_non_vehicle_log_expenses(expense_claim: Document) -> bool:
+	vehicle_log_description = _("Vehicle Expenses")
+	return any(row.description != vehicle_log_description for row in expense_claim.expenses)

--- a/hrms/hr/page/organizational_chart/organizational_chart.py
+++ b/hrms/hr/page/organizational_chart/organizational_chart.py
@@ -3,7 +3,7 @@ from frappe.query_builder.functions import Count
 
 
 @frappe.whitelist()
-def get_children(parent=None, company=None, exclude_node=None):
+def get_children(parent: str | None = None, company: str | None = None, exclude_node: str | None = None):
 	filters = [["status", "=", "Active"]]
 	if company and company != "All Companies":
 		filters.append(["company", "=", company])
@@ -16,7 +16,7 @@ def get_children(parent=None, company=None, exclude_node=None):
 	if exclude_node:
 		filters.append(["name", "!=", exclude_node])
 
-	employees = frappe.get_all(
+	employees = frappe.get_list(
 		"Employee",
 		fields=[
 			"employee_name as name",

--- a/hrms/hr/page/team_updates/team_updates.py
+++ b/hrms/hr/page/team_updates/team_updates.py
@@ -4,8 +4,8 @@ import frappe
 
 
 @frappe.whitelist()
-def get_data(start=0):
-	# frappe.only_for('Employee', 'System Manager')
+def get_data(start: int = 0):
+	frappe.only_for("Employee", "System Manager")
 	data = frappe.get_all(
 		"Communication",
 		fields=("content", "text_content", "sender", "creation"),

--- a/hrms/hr/report/employee_advance_summary/employee_advance_summary.py
+++ b/hrms/hr/report/employee_advance_summary/employee_advance_summary.py
@@ -1,14 +1,18 @@
 # Copyright (c) 2013, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
+from collections import OrderedDict
 
 import frappe
 from frappe import _, msgprint
+from frappe.query_builder import Order
+from frappe.utils import scrub
 
 
 def execute(filters=None):
 	if not filters:
-		filters = {}
+		filters = frappe._dict()
+	filters = frappe._dict(filters)
 
 	advances_list = get_advances(filters)
 	columns = get_columns()
@@ -17,21 +21,118 @@ def execute(filters=None):
 		msgprint(_("No record found"))
 		return columns, advances_list
 
-	data = []
-	for advance in advances_list:
-		row = [
-			advance.name,
-			advance.employee,
-			advance.company,
-			advance.posting_date,
-			advance.advance_amount,
-			advance.paid_amount,
-			advance.claimed_amount,
-			advance.status,
-		]
-		data.append(row)
+	grouped = OrderedDict()
+	group_totals = OrderedDict()
+	group_labels = OrderedDict()
 
-	return columns, data
+	for advance in advances_list:
+		advance.outstanding_amount = advance.paid_amount - (advance.claimed_amount + advance.return_amount)
+		advance.department = advance.department or advance.employee_department
+
+		if filters.get("group_by"):
+			group_key = advance.get(scrub(filters.get("group_by")))
+
+			grouped.setdefault(group_key, []).append(advance)
+
+			if group_key not in group_totals:
+				group_labels[group_key] = (
+					f"{advance.employee}: {advance.employee_name}"
+					if filters.get("group_by") == "Employee" and advance.employee_name
+					else group_key
+				) or group_key
+
+				group_totals[group_key] = frappe._dict(
+					advance_amount=0,
+					paid_amount=0,
+					claimed_amount=0,
+					return_amount=0,
+					outstanding_amount=0,
+					currency=advance.currency,
+				)
+
+			group_totals[group_key].advance_amount += advance.advance_amount or 0
+			group_totals[group_key].paid_amount += advance.paid_amount or 0
+			group_totals[group_key].claimed_amount += advance.claimed_amount or 0
+			group_totals[group_key].return_amount += advance.return_amount or 0
+			group_totals[group_key].outstanding_amount += advance.outstanding_amount
+
+	if not filters.get("group_by"):
+		for row in advances_list:
+			row.title = row.name
+			row.outstanding_amount = row.paid_amount - (row.claimed_amount + row.return_amount)
+			row.department = row.department or row.employee_department
+			if row.employee_name:
+				row.employee = f"{row.employee}: {row.employee_name}"
+		return columns, advances_list
+
+	result = []
+	grand_total = frappe._dict(
+		advance_amount=0, paid_amount=0, claimed_amount=0, return_amount=0, outstanding_amount=0
+	)
+	first_currency = None
+
+	for key, rows in grouped.items():
+		totals = group_totals[key]
+
+		if not first_currency:
+			first_currency = totals.currency
+
+		grand_total.advance_amount += totals.advance_amount
+		grand_total.paid_amount += totals.paid_amount
+		grand_total.claimed_amount += totals.claimed_amount
+		grand_total.return_amount += totals.return_amount
+		grand_total.outstanding_amount += totals.outstanding_amount
+
+		result.append(
+			frappe._dict(
+				title=group_labels.get(key) or _("Not Set"),
+				advance_amount=totals.advance_amount,
+				paid_amount=totals.paid_amount,
+				claimed_amount=totals.claimed_amount,
+				return_amount=totals.return_amount,
+				outstanding_amount=totals.outstanding_amount,
+				currency=totals.currency,
+				bold=1,
+				indent=0,
+			)
+		)
+
+		for row in rows:
+			result.append(
+				frappe._dict(
+					title=row.name,
+					employee=f"{row.employee}: {row.employee_name}" if row.employee_name else row.employee,
+					advance_account=row.advance_account,
+					department=row.department,
+					branch=row.branch,
+					company=row.company,
+					posting_date=row.posting_date,
+					advance_amount=row.advance_amount,
+					paid_amount=row.paid_amount,
+					claimed_amount=row.claimed_amount,
+					return_amount=row.return_amount,
+					outstanding_amount=row.outstanding_amount,
+					status=row.status,
+					currency=row.currency,
+					indent=1,
+				)
+			)
+
+	result.append(
+		frappe._dict(
+			title=_("Total"),
+			advance_amount=grand_total.advance_amount,
+			paid_amount=grand_total.paid_amount,
+			claimed_amount=grand_total.claimed_amount,
+			return_amount=grand_total.return_amount,
+			outstanding_amount=grand_total.outstanding_amount,
+			currency=first_currency,
+			bold=1,
+			indent=0,
+		)
+	)
+
+	return columns, result, None, None, None, 1
 
 
 def get_columns():
@@ -41,13 +142,33 @@ def get_columns():
 			"fieldname": "title",
 			"fieldtype": "Link",
 			"options": "Employee Advance",
-			"width": 120,
+			"width": 160,
 		},
 		{
 			"label": _("Employee"),
 			"fieldname": "employee",
+			"fieldtype": "Data",
+			"width": 180,
+		},
+		{
+			"label": _("Advance Account"),
+			"fieldname": "advance_account",
 			"fieldtype": "Link",
-			"options": "Employee",
+			"options": "Account",
+			"width": 160,
+		},
+		{
+			"label": _("Department"),
+			"fieldname": "department",
+			"fieldtype": "Link",
+			"options": "Department",
+			"width": 120,
+		},
+		{
+			"label": _("Branch"),
+			"fieldname": "branch",
+			"fieldtype": "Link",
+			"options": "Branch",
 			"width": 120,
 		},
 		{
@@ -62,44 +183,111 @@ def get_columns():
 			"label": _("Advance Amount"),
 			"fieldname": "advance_amount",
 			"fieldtype": "Currency",
+			"options": "currency",
+			"width": 130,
+		},
+		{
+			"label": _("Paid Amount"),
+			"fieldname": "paid_amount",
+			"fieldtype": "Currency",
+			"options": "currency",
 			"width": 120,
 		},
-		{"label": _("Paid Amount"), "fieldname": "paid_amount", "fieldtype": "Currency", "width": 120},
 		{
 			"label": _("Claimed Amount"),
 			"fieldname": "claimed_amount",
 			"fieldtype": "Currency",
-			"width": 120,
+			"options": "currency",
+			"width": 130,
+		},
+		{
+			"label": _("Returned Amount"),
+			"fieldname": "return_amount",
+			"fieldtype": "Currency",
+			"options": "currency",
+			"width": 130,
+		},
+		{
+			"label": _("Outstanding Amount"),
+			"fieldname": "outstanding_amount",
+			"fieldtype": "Currency",
+			"options": "currency",
+			"width": 140,
 		},
 		{"label": _("Status"), "fieldname": "status", "fieldtype": "Data", "width": 120},
+		{
+			"label": _("Currency"),
+			"fieldtype": "Link",
+			"fieldname": "currency",
+			"options": "Currency",
+			"hidden": 1,
+			"width": 120,
+		},
 	]
 
 
-def get_conditions(filters):
-	conditions = ""
+def get_advances(filters):
+	EmployeeAdvance = frappe.qb.DocType("Employee Advance")
+	Employee = frappe.qb.DocType("Employee")
+
+	query = (
+		frappe.qb.from_(EmployeeAdvance)
+		.left_join(Employee)
+		.on(EmployeeAdvance.employee == Employee.name)
+		.select(
+			EmployeeAdvance.name,
+			EmployeeAdvance.employee,
+			Employee.employee_name,
+			Employee.branch,
+			Employee.department.as_("employee_department"),
+			EmployeeAdvance.advance_account,
+			EmployeeAdvance.department,
+			EmployeeAdvance.paid_amount,
+			EmployeeAdvance.status,
+			EmployeeAdvance.advance_amount,
+			EmployeeAdvance.claimed_amount,
+			EmployeeAdvance.return_amount,
+			EmployeeAdvance.company,
+			EmployeeAdvance.posting_date,
+			EmployeeAdvance.currency,
+		)
+		.where(EmployeeAdvance.docstatus < 2)
+	)
 
 	if filters.get("employee"):
-		conditions += "and employee = %(employee)s"
+		query = query.where(EmployeeAdvance.employee == filters.get("employee"))
+
 	if filters.get("company"):
-		conditions += " and company = %(company)s"
+		query = query.where(EmployeeAdvance.company == filters.get("company"))
+
 	if filters.get("status"):
-		conditions += " and status = %(status)s"
+		query = query.where(EmployeeAdvance.status == filters.get("status"))
+
 	if filters.get("from_date"):
-		conditions += " and posting_date>=%(from_date)s"
+		query = query.where(EmployeeAdvance.posting_date >= filters.get("from_date"))
+
 	if filters.get("to_date"):
-		conditions += " and posting_date<=%(to_date)s"
+		query = query.where(EmployeeAdvance.posting_date <= filters.get("to_date"))
 
-	return conditions
+	if filters.get("department"):
+		query = query.where(
+			(EmployeeAdvance.department.isin(filters.get("department")))
+			| (EmployeeAdvance.department.isnull() & (Employee.department.isin(filters.get("department"))))
+		)
 
+	if filters.get("branch"):
+		query = query.where(Employee.branch.isin(filters.get("branch")))
 
-def get_advances(filters):
-	conditions = get_conditions(filters)
-	return frappe.db.sql(
-		"""select name, employee, paid_amount, status, advance_amount, claimed_amount, company,
-		posting_date, purpose
-		from `tabEmployee Advance`
-		where docstatus<2 %s order by posting_date, name desc"""
-		% conditions,
-		filters,
-		as_dict=1,
-	)
+	if filters.get("advance_account"):
+		query = query.where(EmployeeAdvance.advance_account.isin(filters.get("advance_account")))
+
+	if filters.get("group_by") == "Department":
+		query = query.orderby(EmployeeAdvance.department)
+	elif filters.get("group_by") == "Branch":
+		query = query.orderby(Employee.branch)
+	else:
+		query = query.orderby(EmployeeAdvance.employee)
+
+	query = query.orderby(EmployeeAdvance.posting_date, order=Order.desc)
+
+	return query.run(as_dict=True)

--- a/hrms/hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py
+++ b/hrms/hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py
@@ -34,7 +34,7 @@ class EmployeeHoursReport:
 		if not self.standard_working_hours:
 			msg = _("The metrics for this report are calculated based on {0}. Please set {0} in {1}.").format(
 				frappe.bold(_("Standard Working Hours")),
-				frappe.utils.get_link_to_form("HR Settings", "HR Settings"),
+				frappe.utils.get_link_to_form("HR Settings", "HR Settings", _("HR Settings")),
 			)
 
 			frappe.throw(msg)
@@ -127,30 +127,32 @@ class EmployeeHoursReport:
 		self.stats_by_employee = filtered_data
 
 	def generate_filtered_time_logs(self):
-		additional_filters = ""
+		Timesheet = frappe.qb.DocType("Timesheet")
+		TimesheetDetail = frappe.qb.DocType("Timesheet Detail")
 
-		filter_fields = ["employee", "project", "company"]
-
-		for field in filter_fields:
-			if self.filters.get(field):
-				if field == "project":
-					additional_filters += f" AND ttd.{field} = {self.filters.get(field)!r}"
-				else:
-					additional_filters += f" AND tt.{field} = {self.filters.get(field)!r}"
-
-		# nosemgrep: frappe-semgrep-rules.rules.frappe-using-db-sql
-		self.filtered_time_logs = frappe.db.sql(
-			f"""
-			SELECT tt.employee AS employee, ttd.hours AS hours, ttd.is_billable AS is_billable, ttd.project AS project
-			FROM `tabTimesheet Detail` AS ttd
-			JOIN `tabTimesheet` AS tt
-				ON ttd.parent = tt.name
-			WHERE tt.employee IS NOT NULL
-			AND tt.start_date BETWEEN '{self.filters.from_date}' AND '{self.filters.to_date}'
-			AND tt.end_date BETWEEN '{self.filters.from_date}' AND '{self.filters.to_date}'
-			{additional_filters}
-		"""
+		query = (
+			frappe.qb.from_(TimesheetDetail)
+			.join(Timesheet)
+			.on(TimesheetDetail.parent == Timesheet.name)
+			.select(
+				Timesheet.employee.as_("employee"),
+				TimesheetDetail.hours.as_("hours"),
+				TimesheetDetail.is_billable.as_("is_billable"),
+				TimesheetDetail.project.as_("project"),
+			)
+			.where(Timesheet.employee.isnotnull())
+			.where(Timesheet.start_date[self.from_date : self.to_date])
+			.where(Timesheet.end_date[self.from_date : self.to_date])
 		)
+
+		for field in ("employee", "company"):
+			if self.filters.get(field):
+				query = query.where(Timesheet[field] == self.filters.get(field))
+
+		if self.filters.get("project"):
+			query = query.where(TimesheetDetail.project == self.filters.get("project"))
+
+		self.filtered_time_logs = query.run()
 
 	def generate_stats_by_employee(self):
 		self.stats_by_employee = frappe._dict()
@@ -166,12 +168,10 @@ class EmployeeHoursReport:
 				self.stats_by_employee[emp]["non_billed_hours"] += flt(hours, 2)
 
 	def set_employee_department_and_name(self):
-		for emp in self.stats_by_employee:
-			emp_name = frappe.db.get_value("Employee", emp, "employee_name")
-			emp_dept = frappe.db.get_value("Employee", emp, "department")
-
-			self.stats_by_employee[emp]["department"] = emp_dept
-			self.stats_by_employee[emp]["employee_name"] = emp_name
+		for emp, stats in self.stats_by_employee.items():
+			stats["employee_name"], stats["department"] = frappe.get_value(
+				"Employee", emp, ["employee_name", "department"]
+			)
 
 	def calculate_utilizations(self):
 		TOTAL_HOURS = flt(self.standard_working_hours * self.day_span, 2)

--- a/hrms/hr/report/employee_leave_balance/test_employee_leave_balance.py
+++ b/hrms/hr/report/employee_leave_balance/test_employee_leave_balance.py
@@ -3,26 +3,29 @@
 
 
 import frappe
-from frappe.tests import IntegrationTestCase
 from frappe.utils import add_days, add_months, flt, get_year_ending, get_year_start, getdate
 
 from erpnext.setup.doctype.employee.test_employee import make_employee
-from erpnext.setup.doctype.holiday_list.test_holiday_list import set_holiday_list
 
+from hrms.hr.doctype.holiday_list_assignment.test_holiday_list_assignment import assign_holiday_list
 from hrms.hr.doctype.leave_application.test_leave_application import make_allocation_record
-from hrms.hr.doctype.leave_ledger_entry.leave_ledger_entry import process_expired_allocation
+from hrms.hr.doctype.leave_ledger_entry.leave_ledger_entry import (
+	expire_allocation,
+	process_expired_allocation,
+)
 from hrms.hr.doctype.leave_type.test_leave_type import create_leave_type
 from hrms.hr.report.employee_leave_balance.employee_leave_balance import execute
 from hrms.payroll.doctype.salary_slip.test_salary_slip import (
 	make_holiday_list,
 	make_leave_application,
 )
-from hrms.tests.test_utils import get_first_sunday
+from hrms.tests.test_utils import get_first_day, get_first_sunday, get_last_day
+from hrms.tests.utils import HRMSTestSuite
 
 test_records = frappe.get_test_records("Leave Type")
 
 
-class TestEmployeeLeaveBalance(IntegrationTestCase):
+class TestEmployeeLeaveBalance(HRMSTestSuite):
 	def setUp(self):
 		for dt in [
 			"Leave Application",
@@ -46,10 +49,7 @@ class TestEmployeeLeaveBalance(IntegrationTestCase):
 			"_Test Emp Balance Holiday List", self.year_start, self.year_end
 		)
 
-	def tearDown(self):
-		frappe.db.rollback()
-
-	@set_holiday_list("_Test Emp Balance Holiday List", "_Test Company")
+	@assign_holiday_list("_Test Emp Balance Holiday List", "_Test Company")
 	def test_employee_leave_balance(self):
 		frappe.get_doc(test_records[0]).insert()
 
@@ -100,7 +100,7 @@ class TestEmployeeLeaveBalance(IntegrationTestCase):
 
 		self.assertEqual(report[1], expected_data)
 
-	@set_holiday_list("_Test Emp Balance Holiday List", "_Test Company")
+	@assign_holiday_list("_Test Emp Balance Holiday List", "_Test Company")
 	def test_opening_balance_on_alloc_boundary_dates(self):
 		frappe.get_doc(test_records[0]).insert()
 
@@ -151,7 +151,7 @@ class TestEmployeeLeaveBalance(IntegrationTestCase):
 			(allocation1.new_leaves_allocated - leave_application.total_leave_days),
 		)
 
-	@set_holiday_list("_Test Emp Balance Holiday List", "_Test Company")
+	@assign_holiday_list("_Test Emp Balance Holiday List", "_Test Company")
 	def test_opening_balance_considers_carry_forwarded_leaves(self):
 		leave_type = create_leave_type(leave_type_name="_Test_CF_leave_expiry", is_carry_forward=1)
 
@@ -205,7 +205,59 @@ class TestEmployeeLeaveBalance(IntegrationTestCase):
 		)
 		self.assertEqual(report[1][0].opening_balance, opening_balance)
 
-	@set_holiday_list("_Test Emp Balance Holiday List", "_Test Company")
+	def test_carry_forwarded_leaves_are_included_when_they_expire(self):
+		leave_type = create_leave_type(
+			leave_type_name="_Test_CF_report_expiry",
+			is_carry_forward=1,
+			expire_carry_forwarded_leaves_after_days=7,
+		)
+
+		previous_allocation = make_allocation_record(
+			employee=self.employee_id,
+			from_date=add_days(self.date, -45),
+			to_date=add_days(self.date, -31),
+			leave_type=leave_type.name,
+			leaves=7,
+		)
+		current_allocation = make_allocation_record(
+			employee=self.employee_id,
+			from_date=add_days(self.date, -20),
+			to_date=add_days(self.date, 30),
+			carry_forward=True,
+			leave_type=leave_type.name,
+			leaves=11,
+		)
+
+		leave_application = make_leave_application(
+			self.employee_id,
+			add_days(current_allocation.from_date, 8),
+			add_days(current_allocation.from_date, 16),
+			leave_type.name,
+		)
+		leave_application.reload()
+		process_expired_allocation()
+
+		filters = frappe._dict(
+			{
+				"from_date": current_allocation.from_date,
+				"to_date": current_allocation.to_date,
+				"employee": self.employee_id,
+			}
+		)
+		report = execute(filters)
+		row = next(row for row in report[1] if row.leave_type == leave_type.name)
+
+		expected_allocated = current_allocation.new_leaves_allocated + current_allocation.unused_leaves
+		expected_closing = row.opening_balance + row.leaves_allocated - row.leaves_expired - row.leaves_taken
+
+		self.assertEqual(current_allocation.unused_leaves, previous_allocation.new_leaves_allocated)
+		self.assertEqual(row.opening_balance, 0)
+		self.assertEqual(row.leaves_allocated, flt(expected_allocated))
+		self.assertEqual(row.leaves_expired, flt(current_allocation.unused_leaves))
+		self.assertEqual(row.leaves_taken, flt(leave_application.total_leave_days))
+		self.assertEqual(row.closing_balance, flt(expected_closing))
+
+	@assign_holiday_list("_Test Emp Balance Holiday List", "_Test Company")
 	def test_employee_status_filter(self):
 		frappe.get_doc(test_records[0]).insert()
 		inactive_emp = make_employee("test_emp_status@example.com", company="_Test Company")
@@ -242,46 +294,40 @@ class TestEmployeeLeaveBalance(IntegrationTestCase):
 		report = execute(filters)
 		self.assertEqual(len(report[1]), 1)
 
-	@set_holiday_list("_Test Emp Balance Holiday List", "_Test Company")
-	def test_closing_balance_considers_carry_forwarded_leaves(self):
-		leave_type = create_leave_type(leave_type_name="_Test_CF_leave_expiry", is_carry_forward=1)
-		# 30 leaves allocated for first half of the year
-		allocation1 = make_allocation_record(
-			employee=self.employee_id,
-			from_date=self.year_start,
-			to_date=self.mid_year,
+	def test_manually_expired_leaves(self):
+		leave_type = create_leave_type(leave_type_name="Compensatory off")
+		employee = make_employee("test_expired_leaves@example.com", company="_Test Company")
+		leave_allocation = make_allocation_record(
+			employee=employee,
 			leave_type=leave_type.name,
-		)
-		# 4 days leave application in the first allocation
-		first_sunday = get_first_sunday(self.holiday_list, for_date=self.year_start)
-		leave_application = make_leave_application(
-			self.employee_id, first_sunday, add_days(first_sunday, 3), leave_type.name
-		)
-		leave_application.reload()
-		# expires 26 leaves
-		process_expired_allocation()
-		# carry forward 26 expired leaves + allocate 4 new leaves
-		allocation2 = make_allocation_record(
-			employee=self.employee_id,
-			from_date=add_days(self.mid_year, 1),
-			to_date=self.year_end,
-			leaves=4,
-			carry_forward=True,
-			leave_type=leave_type.name,
+			leaves=5,
+			from_date=get_first_day(getdate()),
+			to_date=get_last_day(getdate()),
 		)
 
+		expire_allocation(leave_allocation, expiry_date=add_days(get_first_day(getdate()), 15))
+
+		# closing balance should be 5 before allocation expiry date
 		filters = frappe._dict(
 			{
-				"from_date": self.year_start,
-				"to_date": self.year_end,
-				"employee": self.employee_id,
+				"from_date": get_first_day(getdate()),
+				"to_date": add_days(get_first_day(getdate()), 10),
+				"employee": employee,
+			}
+		)
+		report = execute(filters)
+		self.assertEqual(report[1][0].closing_balance, 5)
+		self.assertEqual(report[1][0].leaves_expired, 0)
+
+		# closing balance should be 0 after allocation expiry date
+		filters = frappe._dict(
+			{
+				"from_date": get_first_day(getdate()),
+				"to_date": get_last_day(getdate()),
+				"employee": employee,
 			}
 		)
 		report = execute(filters)
 
-		closing_balance = (
-			allocation1.new_leaves_allocated
-			- leave_application.total_leave_days
-			+ allocation2.new_leaves_allocated
-		)
-		self.assertEqual(report[1][0].closing_balance, closing_balance)
+		self.assertEqual(report[1][0].closing_balance, 0)
+		self.assertEqual(report[1][0].leaves_expired, 5)

--- a/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
@@ -1,22 +1,15 @@
-# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
-# License: GNU General Public License v3. See license.txt
-
-
-from calendar import monthrange
-from datetime import date
-from itertools import groupby
-
-from pypika import Field
-from pypika.terms import Criterion
+from dateutil.relativedelta import relativedelta
 
 import frappe
-from frappe.tests import IntegrationTestCase
 from frappe.utils import add_days, get_year_ending, get_year_start, getdate
 
 from erpnext.setup.doctype.employee.test_employee import make_employee
-from erpnext.setup.doctype.holiday_list.test_holiday_list import set_holiday_list
 
 from hrms.hr.doctype.attendance.attendance import mark_attendance
+from hrms.hr.doctype.holiday_list_assignment.test_holiday_list_assignment import (
+	assign_holiday_list,
+	create_holiday_list_assignment,
+)
 from hrms.hr.doctype.leave_allocation.leave_allocation import OverlapError
 from hrms.hr.doctype.leave_application.test_leave_application import make_allocation_record
 from hrms.hr.doctype.shift_type.test_shift_type import setup_shift_type
@@ -25,15 +18,17 @@ from hrms.payroll.doctype.salary_slip.test_salary_slip import (
 	make_holiday_list,
 	make_leave_application,
 )
-from hrms.tests.test_utils import create_company, get_first_day_for_prev_month
+from hrms.tests.test_utils import create_company, create_department, get_first_day_for_prev_month
+from hrms.tests.utils import HRMSTestSuite
 
 
-class TestMonthlyAttendanceSheet(FrappeTestCase):
+class TestMonthlyAttendanceSheet(HRMSTestSuite):
 	def setUp(self):
 		self.company = "_Test Company"
 		self.employee = make_employee("test_employee@example.com", company=self.company)
 		self.filter_based_on = "Month"
-		frappe.db.delete("Attendance")
+		for dt in ("Attendance", "Leave Application"):
+			frappe.db.delete(dt)
 
 		if not frappe.db.exists("Shift Type", "Day Shift"):
 			setup_shift_type(shift_type="Day Shift")
@@ -43,7 +38,7 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 		to_date = get_year_ending(date)
 		make_holiday_list(from_date=from_date, to_date=to_date)
 
-	@set_holiday_list("Salary Slip Test Holiday List", "_Test Company")
+	@assign_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_monthly_attendance_sheet_report(self):
 		previous_month_first = get_first_day_for_prev_month()
 
@@ -78,7 +73,7 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 		self.assertEqual(present[1], 1)
 		self.assertEqual(leaves[2], 1)
 
-	@set_holiday_list("Salary Slip Test Holiday List", "_Test Company")
+	@assign_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_detailed_view(self):
 		previous_month_first = get_first_day_for_prev_month()
 
@@ -123,7 +118,7 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 			== "L"
 		)
 
-	@set_holiday_list("Salary Slip Test Holiday List", "_Test Company")
+	@assign_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_single_shift_with_leaves_in_detailed_view(self):
 		previous_month_first = get_first_day_for_prev_month()
 
@@ -159,7 +154,7 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 			day_shift_row[date_key(add_days(previous_month_first, 2))], "L"
 		)  # leave on the 3rd day
 
-	@set_holiday_list("Salary Slip Test Holiday List", "_Test Company")
+	@assign_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_single_leave_record(self):
 		previous_month_first = get_first_day_for_prev_month()
 
@@ -183,7 +178,7 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 		self.assertIsNone(row["shift"])
 		self.assertEqual(row[date_key(previous_month_first)], "L")
 
-	@set_holiday_list("Salary Slip Test Holiday List", "_Test Company")
+	@assign_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_summarized_view(self):
 		previous_month_first = get_first_day_for_prev_month()
 
@@ -229,7 +224,7 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 		self.assertEqual(row["total_late_entries"], 1)
 		self.assertEqual(row["total_early_exits"], 1)
 
-	@set_holiday_list("Salary Slip Test Holiday List", "_Test Company")
+	@assign_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_attendance_with_group_by_filter(self):
 		previous_month_first = get_first_day_for_prev_month()
 
@@ -328,9 +323,9 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 		self.assertEqual(leaves[2], 1)
 
 	def test_attendance_with_company_filter(self):
-		create_company("Test Parent Company", is_group=1)
-		create_company("Test Child Company", is_group=1, parent_company="Test Parent Company")
-		create_company("Test Grandchild Company", parent_company="Test Child Company")
+		create_company("Test Parent Company", is_group=1, abbr="TPC-HR")
+		create_company("Test Child Company", is_group=1, parent_company="Test Parent Company", abbr="TCC-HR")
+		create_company("Test Grandchild Company", parent_company="Test Child Company", abbr="TGC-HR")
 
 		employee1 = make_employee("test_employee@parent.com", company="Test Parent Company")
 		employee2 = make_employee("test_employee@child.com", company="Test Child Company")
@@ -405,7 +400,7 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 		self.assertEqual(present[1], 1)
 		self.assertEqual(leaves[2], 1)
 
-	@set_holiday_list("Salary Slip Test Holiday List", "_Test Company")
+	@assign_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_validations(self):
 		# validation error for filters without filter based on
 		self.assertRaises(
@@ -449,23 +444,29 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 		self.assertEqual(report, ([], [], None, None))
 
 	def test_summarised_view_with_date_range_filter(self):
-		today = getdate()
+		previous_month_first = get_first_day_for_prev_month()
 
 		# attendance with shift
-		mark_attendance(self.employee, today, "Absent", "Day Shift")
-		mark_attendance(self.employee, today + relativedelta(days=1), "Present", "Day Shift")
-		mark_attendance(self.employee, today + relativedelta(days=2), "Half Day")  # half day
+		mark_attendance(self.employee, previous_month_first, "Absent", "Day Shift")
+		mark_attendance(self.employee, previous_month_first + relativedelta(days=1), "Present", "Day Shift")
+		mark_attendance(self.employee, previous_month_first + relativedelta(days=2), "Half Day")  # half day
 
-		mark_attendance(self.employee, today + relativedelta(days=3), "Present")  # attendance without shift
-		mark_attendance(self.employee, today + relativedelta(days=4), "Present", late_entry=1)  # late entry
-		mark_attendance(self.employee, today + relativedelta(days=5), "Present", early_exit=1)  # early exit
+		mark_attendance(
+			self.employee, previous_month_first + relativedelta(days=3), "Present"
+		)  # attendance without shift
+		mark_attendance(
+			self.employee, previous_month_first + relativedelta(days=4), "Present", late_entry=1
+		)  # late entry
+		mark_attendance(
+			self.employee, previous_month_first + relativedelta(days=5), "Present", early_exit=1
+		)  # early exit
 
-		leave_application = get_leave_application(self.employee, today)
+		leave_application = get_leave_application(self.employee, previous_month_first)
 
 		filters = frappe._dict(
 			{
-				"start_date": add_days(today, -1),
-				"end_date": add_days(today, 30),
+				"start_date": add_days(previous_month_first, -1),
+				"end_date": add_days(previous_month_first, 30),
 				"company": self.company,
 				"summarized_view": 1,
 				"filter_based_on": "Date Range",
@@ -521,6 +522,211 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 			== "L"
 		)
 
+	def test_attendance_with_department_filter(self):
+		previous_month_first = get_first_day_for_prev_month()
+
+		dept1 = create_department("Test Dept Alpha")
+		dept2 = create_department("Test Dept Beta")
+
+		emp_dept1 = make_employee("emp_dept1@example.com", company=self.company, department=dept1)
+		emp_dept2 = make_employee("emp_dept2@example.com", company=self.company, department=dept2)
+
+		mark_attendance(emp_dept1, previous_month_first, "Present")
+		mark_attendance(emp_dept2, previous_month_first, "Present")
+
+		filters = frappe._dict(
+			{
+				"month": previous_month_first.month,
+				"year": previous_month_first.year,
+				"company": self.company,
+				"department": dept1,
+				"filter_based_on": self.filter_based_on,
+			}
+		)
+		report = execute(filters=filters)
+
+		employees_in_report = [row.get("employee") for row in report[1] if row.get("employee")]
+
+		# only emp_dept1 should appear; emp_dept2 belongs to a different department
+		self.assertIn(emp_dept1, employees_in_report)
+		self.assertNotIn(emp_dept2, employees_in_report)
+
+	def test_attendance_with_branch_filter(self):
+		previous_month_first = get_first_day_for_prev_month()
+
+		branch1 = create_branch("Test Branch Alpha")
+		branch2 = create_branch("Test Branch Beta")
+
+		emp_branch1 = make_employee("emp_branch1@example.com", company=self.company, branch=branch1)
+		emp_branch2 = make_employee("emp_branch2@example.com", company=self.company, branch=branch2)
+
+		mark_attendance(emp_branch1, previous_month_first, "Present")
+		mark_attendance(emp_branch2, previous_month_first, "Present")
+
+		filters = frappe._dict(
+			{
+				"month": previous_month_first.month,
+				"year": previous_month_first.year,
+				"company": self.company,
+				"branch": branch1,
+				"filter_based_on": self.filter_based_on,
+			}
+		)
+		report = execute(filters=filters)
+
+		employees_in_report = [row.get("employee") for row in report[1] if row.get("employee")]
+
+		# only emp_branch1 should appear; emp_branch2 belongs to a different branch
+		self.assertIn(emp_branch1, employees_in_report)
+		self.assertNotIn(emp_branch2, employees_in_report)
+
+	def test_attendance_with_department_and_branch_filter_combined(self):
+		previous_month_first = get_first_day_for_prev_month()
+
+		dept = create_department("Test Dept Combined")
+		branch = create_branch("Test Branch Combined")
+
+		# employee matching both department and branch
+		emp_match = make_employee(
+			"emp_match@example.com", company=self.company, department=dept, branch=branch
+		)
+		# employee with correct department but wrong branch
+		emp_wrong_branch = make_employee(
+			"emp_wrong_branch@example.com",
+			company=self.company,
+			department=dept,
+			branch=create_branch("Test Branch Other"),
+		)
+		# employee with correct branch but wrong department
+		emp_wrong_dept = make_employee(
+			"emp_wrong_dept@example.com",
+			company=self.company,
+			department=create_department("Test Dept Other"),
+			branch=branch,
+		)
+
+		mark_attendance(emp_match, previous_month_first, "Present")
+		mark_attendance(emp_wrong_branch, previous_month_first, "Present")
+		mark_attendance(emp_wrong_dept, previous_month_first, "Present")
+
+		filters = frappe._dict(
+			{
+				"month": previous_month_first.month,
+				"year": previous_month_first.year,
+				"company": self.company,
+				"department": dept,
+				"branch": branch,
+				"filter_based_on": self.filter_based_on,
+			}
+		)
+		report = execute(filters=filters)
+
+		employees_in_report = [row.get("employee") for row in report[1] if row.get("employee")]
+
+		# only the employee matching both department and branch should appear
+		self.assertIn(emp_match, employees_in_report)
+		self.assertNotIn(emp_wrong_branch, employees_in_report)
+		self.assertNotIn(emp_wrong_dept, employees_in_report)
+
+	def test_multiple_holiday_list_assignments_in_detailed_view(self):
+		"""
+		Employee switches holiday lists mid-month.
+		Holidays from each list must appear only within their effective date range.
+
+		HL-1 active days 1-15: holiday on day 5 AND day 20 (day 20 should NOT appear)
+		HL-2 active days 16-end: holiday on day 10 AND day 25 (day 10 should NOT appear)
+		"""
+		previous_month_first = get_first_day_for_prev_month()
+		year_start = getdate(get_year_start(previous_month_first))
+		year_end = getdate(get_year_ending(previous_month_first))
+
+		hl1_day = previous_month_first.replace(day=5)  # in HL-1's range
+		hl1_bleed = previous_month_first.replace(day=20)  # HL-1 holiday outside its range
+		hl2_bleed = previous_month_first.replace(day=10)  # HL-2 holiday before it becomes active
+		hl2_day = previous_month_first.replace(day=25)  # in HL-2's range
+		hl2_start = previous_month_first.replace(day=16)
+
+		hl1 = make_holiday_list(
+			"Test Multi HL-1", from_date=year_start, to_date=year_end, add_weekly_offs=False
+		)
+		hl2 = make_holiday_list(
+			"Test Multi HL-2", from_date=year_start, to_date=year_end, add_weekly_offs=False
+		)
+
+		add_holiday_to_list(hl1, hl1_day)
+		add_holiday_to_list(hl1, hl1_bleed)  # outside effective range — must not show
+		add_holiday_to_list(hl2, hl2_bleed)  # before HL-2 becomes active — must not show
+		add_holiday_to_list(hl2, hl2_day)
+
+		frappe.db.delete("Holiday List Assignment", {"assigned_to": self.employee})
+		create_holiday_list_assignment("Employee", self.employee, hl1, from_date=previous_month_first)
+		create_holiday_list_assignment("Employee", self.employee, hl2, from_date=hl2_start)
+
+		mark_attendance(self.employee, previous_month_first, "Present")
+
+		filters = frappe._dict(
+			{
+				"month": previous_month_first.month,
+				"year": previous_month_first.year,
+				"company": self.company,
+				"filter_based_on": "Month",
+			}
+		)
+		report = execute(filters=filters)
+		row = report[1][0]
+
+		# holiday in HL-1's active window → must appear
+		self.assertEqual(row[date_key(hl1_day)], "H")
+		# holiday in HL-2's active window → must appear
+		self.assertEqual(row[date_key(hl2_day)], "H")
+		# HL-1 holiday after HL-2 takes over → must NOT appear
+		self.assertNotEqual(row[date_key(hl1_bleed)], "H")
+		# HL-2 holiday before HL-2 becomes active → must NOT appear
+		self.assertNotEqual(row[date_key(hl2_bleed)], "H")
+
+	def test_multiple_holiday_list_assignments_in_summarized_view(self):
+		"""
+		Total holiday count must combine holidays from all active holiday list assignments.
+		"""
+		previous_month_first = get_first_day_for_prev_month()
+		year_start = getdate(get_year_start(previous_month_first))
+		year_end = getdate(get_year_ending(previous_month_first))
+
+		hl1_day = previous_month_first.replace(day=5)
+		hl2_day = previous_month_first.replace(day=25)
+		hl2_start = previous_month_first.replace(day=16)
+
+		hl1 = make_holiday_list(
+			"Test Multi HL-1", from_date=year_start, to_date=year_end, add_weekly_offs=False
+		)
+		hl2 = make_holiday_list(
+			"Test Multi HL-2", from_date=year_start, to_date=year_end, add_weekly_offs=False
+		)
+
+		add_holiday_to_list(hl1, hl1_day)
+		add_holiday_to_list(hl2, hl2_day)
+
+		frappe.db.delete("Holiday List Assignment", {"assigned_to": self.employee})
+		create_holiday_list_assignment("Employee", self.employee, hl1, from_date=previous_month_first)
+		create_holiday_list_assignment("Employee", self.employee, hl2, from_date=hl2_start)
+
+		mark_attendance(self.employee, previous_month_first.replace(day=3), "Present")
+
+		filters = frappe._dict(
+			{
+				"month": previous_month_first.month,
+				"year": previous_month_first.year,
+				"company": self.company,
+				"filter_based_on": "Month",
+				"summarized_view": 1,
+			}
+		)
+		report = execute(filters=filters)
+		row = report[1][0]
+
+		# one holiday from each list → total must be 2
+		self.assertEqual(row["total_holidays"], 2)
+
 	def test_detailed_view_with_date_range_and_group_by_filter(self):
 		today = getdate()
 		mark_attendance(self.employee, today, "Absent", "Day Shift")
@@ -567,8 +773,8 @@ def get_leave_application(employee, date=None):
 		make_allocation_record(employee=employee, from_date=year_start, to_date=year_end)
 	except OverlapError:
 		pass
-	from_date = date + relativedelta(days=7)
-	to_date = date + relativedelta(days=8)
+	from_date = date.replace(day=7)
+	to_date = date.replace(day=8)
 
 	return make_leave_application(employee, from_date, to_date, "_Test Leave Type")
 
@@ -591,3 +797,15 @@ def execute_report_with_invalid_filters(invalid_filter_name):
 
 def date_key(date_obj):
 	return date_obj.strftime("%d-%m-%Y")
+
+
+def create_branch(branch_name):
+	if not frappe.db.exists("Branch", branch_name):
+		frappe.get_doc({"doctype": "Branch", "branch": branch_name}).insert(ignore_permissions=True)
+	return branch_name
+
+
+def add_holiday_to_list(holiday_list_name, holiday_date, description="Test Holiday"):
+	hl = frappe.get_doc("Holiday List", holiday_list_name)
+	hl.append("holidays", {"holiday_date": holiday_date, "description": description, "weekly_off": 0})
+	hl.save()

--- a/hrms/overrides/company.py
+++ b/hrms/overrides/company.py
@@ -83,9 +83,9 @@ def make_salary_components(country):
 			doc.flags.ignore_permissions = True
 			doc.flags.ignore_mandatory = True
 			doc.insert(ignore_if_duplicate=True)
-		except frappe.NameError:
-			frappe.clear_messages()
-		except frappe.DuplicateEntryError:
+		except Exception as e:
+			frappe.error_log("Error occurred while creating Salary Component", e)
+		finally:
 			frappe.clear_messages()
 
 
@@ -133,6 +133,7 @@ def validate_default_accounts(doc, method=None):
 				).format(frappe.bold(_("Default Payroll Payable Account")))
 			)
 
+
 def handle_linked_docs(doc, method=None):
 	delete_docs_with_company_field(doc)
 	clear_company_field_for_single_doctypes(doc)
@@ -144,10 +145,10 @@ def delete_docs_with_company_field(doc, method=None):
 	"""
 	company_data_to_be_ignored = frappe.get_hooks("company_data_to_be_ignored") or []
 	for doctype in company_data_to_be_ignored:
-		# get field in the doctype linked to Company
 		records_to_delete = frappe.get_all(doctype, filters={"company": doc.name}, pluck="name")
 		if records_to_delete:
 			frappe.db.delete(doctype, {"name": ["in", records_to_delete]})
+
 
 def clear_company_field_for_single_doctypes(doc):
 	"""

--- a/hrms/overrides/employee_master.py
+++ b/hrms/overrides/employee_master.py
@@ -4,6 +4,8 @@
 import frappe
 from frappe import _
 from frappe.model.naming import set_name_by_naming_series
+from frappe.query_builder import Interval
+from frappe.query_builder.functions import Count, CurDate, UnixTimestamp
 from frappe.utils import add_years, cint, get_link_to_form, getdate
 
 from erpnext.setup.doctype.employee.employee import Employee
@@ -97,6 +99,7 @@ def update_approver_role(doc, method=None):
 		user.flags.ignore_permissions = True
 		user.add_roles("Expense Approver")
 
+
 def update_approver_user_roles(doc, method=None):
 	approver_roles = set()
 	if frappe.db.exists("Employee", {"leave_approver": doc.name}):
@@ -107,7 +110,8 @@ def update_approver_user_roles(doc, method=None):
 
 	if approver_roles:
 		doc.append_roles(*approver_roles)
-		
+
+
 def update_employee_transfer(doc, method=None):
 	"""Unsets Employee ID in Employee Transfer if doc is deleted"""
 	if frappe.db.exists("Employee Transfer", {"new_employee_id": doc.name, "docstatus": 1}):
@@ -116,25 +120,37 @@ def update_employee_transfer(doc, method=None):
 
 
 @frappe.whitelist()
-def get_timeline_data(doctype, name):
+def get_timeline_data(doctype: str, name: str) -> dict:
 	"""Return timeline for attendance"""
 	from frappe.desk.notifications import get_open_count
 
 	out = {}
 
+	frappe.has_permission(doctype, "read", name, throw=True)
+	frappe.has_permission("Attendance", "read", throw=True)
+
 	open_count = get_open_count(doctype, name)
 	out["count"] = open_count["count"]
 
+	from frappe.query_builder.terms import Function
+
+	Attendance = frappe.qb.DocType("Attendance")
+
 	timeline_data = dict(
-		frappe.db.sql(
-			"""
-			SELECT EXTRACT(EPOCH FROM attendance_date), COUNT(*)
-			from `tabAttendance` where employee=%s
-			AND attendance_date > CURRENT_DATE - INTERVAL '1 year'
-			and status in ('Present', 'Half Day')
-			group by attendance_date""",
-			name,
-		)
+		(
+			frappe.qb.from_(Attendance)
+			.select(
+				Function("unix_timestamp", Attendance.attendance_date),
+				Count("*"),
+			)
+			.where(
+				(Attendance.employee == name)
+				& (Attendance.docstatus == 1)
+				& (Attendance.attendance_date > (CurDate() - Interval(years=1)))
+				& (Attendance.status.isin(["Present", "Half Day"]))
+			)
+			.groupby(Attendance.attendance_date)
+		).run()
 	)
 
 	out["timeline_data"] = timeline_data
@@ -142,7 +158,7 @@ def get_timeline_data(doctype, name):
 
 
 @frappe.whitelist()
-def get_retirement_date(date_of_birth=None):
+def get_retirement_date(date_of_birth: str | None = None):
 	if date_of_birth:
 		try:
 			retirement_age = cint(frappe.db.get_single_value("HR Settings", "retirement_age") or 60)

--- a/hrms/overrides/employee_payment_entry.py
+++ b/hrms/overrides/employee_payment_entry.py
@@ -2,6 +2,7 @@
 # License: GNU General Public License v3. See license.txt
 
 import frappe
+from frappe.model.document import Document
 from frappe.utils import flt, nowdate
 
 import erpnext
@@ -25,7 +26,7 @@ class EmployeePaymentEntry(PaymentEntry):
 		elif self.party_type == "Shareholder":
 			return ("Journal Entry",)
 		elif self.party_type == "Employee":
-			return ("Expense Claim", "Journal Entry", "Employee Advance", "Gratuity")
+			return ("Expense Claim", "Journal Entry", "Employee Advance", "Leave Encashment", "Gratuity")
 
 	def set_missing_ref_details(
 		self,
@@ -73,9 +74,14 @@ class EmployeePaymentEntry(PaymentEntry):
 
 @frappe.whitelist()
 def get_payment_entry_for_employee(
-	dt, dn, party_amount=None, bank_account=None, bank_amount=None
+	dt: str,
+	dn: str,
+	party_amount: float | None = None,
+	bank_account: str | None = None,
+	bank_amount: float | None = None,
 ):
 	"""Function to make Payment Entry for Employee Advance, Gratuity, Expense Claim, Leave Encashment"""
+	frappe.has_permission(dt, "read", dn, throw=True)
 	doc = frappe.get_doc(dt, dn)
 
 	party_account = get_party_account(doc)
@@ -87,10 +93,6 @@ def get_payment_entry_for_employee(
 
 	# bank or cash
 	bank = get_bank_cash_account(doc, bank_account)
-
-	paid_amount, received_amount = get_paid_amount_and_received_amount(
-		doc, party_account_currency, bank, outstanding_amount, payment_type, bank_amount
-	)
 
 	pe = frappe.new_doc("Payment Entry")
 	pe.payment_type = payment_type
@@ -107,8 +109,6 @@ def get_payment_entry_for_employee(
 	pe.paid_to = party_account
 	pe.paid_from_account_currency = bank.account_currency
 	pe.paid_to_account_currency = party_account_currency
-	pe.paid_amount = paid_amount
-	pe.received_amount = received_amount
 
 	pe.append(
 		"references",
@@ -127,11 +127,26 @@ def get_payment_entry_for_employee(
 	pe.set_missing_values()
 	pe.set_missing_ref_details()
 
+	# fetching current exchange rate for advance payment entry
+	current_exchange_rate = get_exchange_rate(
+		pe.paid_to_account_currency, pe.paid_from_account_currency, pe.posting_date
+	)
+	paid_amount, received_amount = get_paid_amount_and_received_amount(
+		doc,
+		party_account_currency,
+		bank,
+		outstanding_amount,
+		payment_type,
+		bank_amount,
+		current_exchange_rate,
+	)
+	pe.paid_amount = paid_amount
+	pe.received_amount = received_amount
+
 	if party_account and bank:
-		reference_doc = None
-		if dt == "Employee Advance":
-			reference_doc = doc
-		pe.set_exchange_rate(ref_doc=reference_doc)
+		pe.set_exchange_rate()  # always set source & target exchange rate
+		if dt == "Employee Advance" and pe.paid_to_account_currency != pe.paid_from_account_currency:
+			pe.target_exchange_rate = current_exchange_rate
 		pe.set_amounts()
 
 	return pe
@@ -155,9 +170,7 @@ def get_grand_total_and_outstanding_amount(doc, party_amount, party_account_curr
 		grand_total = outstanding_amount = party_amount
 
 	elif doc.doctype == "Expense Claim":
-		grand_total = flt(doc.total_sanctioned_amount) + flt(
-			doc.total_taxes_and_charges
-		)
+		grand_total = flt(doc.total_sanctioned_amount) + flt(doc.total_taxes_and_charges)
 		outstanding_amount = get_outstanding_amount_for_claim(doc.name)
 
 	elif doc.doctype == "Employee Advance":
@@ -165,9 +178,7 @@ def get_grand_total_and_outstanding_amount(doc, party_amount, party_account_curr
 		outstanding_amount = flt(doc.advance_amount) - flt(doc.paid_amount)
 		if party_account_currency != doc.currency:
 			grand_total = flt(doc.advance_amount) * flt(doc.exchange_rate)
-			outstanding_amount = (flt(doc.advance_amount) - flt(doc.paid_amount)) * flt(
-				doc.exchange_rate
-			)
+			outstanding_amount = (flt(doc.advance_amount) - flt(doc.paid_amount)) * flt(doc.exchange_rate)
 
 	elif doc.doctype == "Gratuity":
 		grand_total = doc.amount
@@ -188,7 +199,7 @@ def get_grand_total_and_outstanding_amount(doc, party_amount, party_account_curr
 
 
 def get_paid_amount_and_received_amount(
-	doc, party_account_currency, bank, outstanding_amount, payment_type, bank_amount
+	doc, party_account_currency, bank, outstanding_amount, payment_type, bank_amount, exchange_rate
 ):
 	paid_amount = received_amount = 0
 
@@ -212,16 +223,21 @@ def get_paid_amount_and_received_amount(
 			# if party account currency and bank currency is different then populate paid amount as well
 			paid_amount = received_amount * doc.get("conversion_rate", 1)
 			if doc.doctype == "Employee Advance":
-				paid_amount = received_amount * doc.get("exchange_rate", 1)
+				paid_amount = received_amount * exchange_rate
 
 	return paid_amount, received_amount
 
 
 @frappe.whitelist()
 def get_payment_reference_details(
-	reference_doctype, reference_name, party_account_currency, party_type=None, party=None
+	reference_doctype: str,
+	reference_name: str,
+	party_account_currency: str,
+	party_type: str | None = None,
+	party: str | None = None,
 ):
-	if reference_doctype in ("Expense Claim", "Employee Advance", "Gratuity"):
+	frappe.has_permission(reference_doctype, "read", reference_name, throw=True)
+	if reference_doctype in ("Expense Claim", "Employee Advance", "Gratuity", "Leave Encashment"):
 		return get_reference_details_for_employee(reference_doctype, reference_name, party_account_currency)
 	else:
 		return get_reference_details(
@@ -231,12 +247,13 @@ def get_payment_reference_details(
 
 @frappe.whitelist()
 def get_reference_details_for_employee(
-	reference_doctype, reference_name, party_account_currency
+	reference_doctype: str, reference_name: str, party_account_currency: str
 ):
 	"""
 	Returns payment reference details for employee related doctypes:
-		Employee Advance, Expense Claim, Gratuity, Leave Encashment
+	Employee Advance, Expense Claim, Gratuity, Leave Encashment
 	"""
+	frappe.has_permission(reference_doctype, "read", reference_name, throw=True)
 	total_amount = outstanding_amount = exchange_rate = None
 
 	ref_doc = frappe.get_doc(reference_doctype, reference_name)
@@ -269,15 +286,11 @@ def get_reference_details_for_employee(
 	)
 
 
-def get_total_amount_and_exchange_rate(
-	ref_doc, party_account_currency, company_currency
-):
+def get_total_amount_and_exchange_rate(ref_doc, party_account_currency, company_currency):
 	total_amount = exchange_rate = None
 
 	if ref_doc.doctype == "Expense Claim":
-		total_amount = flt(ref_doc.total_sanctioned_amount) + flt(
-			ref_doc.total_taxes_and_charges
-		)
+		total_amount = flt(ref_doc.total_sanctioned_amount) + flt(ref_doc.total_taxes_and_charges)
 	elif ref_doc.doctype == "Employee Advance":
 		total_amount = ref_doc.advance_amount
 		exchange_rate = ref_doc.get("exchange_rate")
@@ -285,10 +298,8 @@ def get_total_amount_and_exchange_rate(
 			total_amount = flt(total_amount) * flt(exchange_rate)
 		if party_account_currency == company_currency and party_account_currency == ref_doc.currency:
 			exchange_rate = 1
-
 	elif ref_doc.doctype == "Leave Encashment":
 		total_amount = ref_doc.encashment_amount
-
 	elif ref_doc.doctype == "Gratuity":
 		total_amount = ref_doc.amount
 
@@ -307,3 +318,19 @@ def get_total_amount_and_exchange_rate(
 		)
 
 	return total_amount, exchange_rate
+
+
+# update exchange rate in linked advance
+@frappe.whitelist()
+def set_exchange_rate_in_advance(doc: Document, method: None = None):
+	if doc.references:
+		for reference_doc in doc.references:
+			if reference_doc.reference_doctype == "Employee Advance" and doc.target_exchange_rate:
+				frappe.has_permission("Employee Advance", "write", reference_doc.reference_name, throw=True)
+				frappe.db.set_value(
+					"Employee Advance",
+					reference_doc.reference_name,
+					"exchange_rate",
+					doc.target_exchange_rate,
+					update_modified=False,
+				)

--- a/hrms/patches/post_install/move_payroll_setting_separately_from_hr_settings.py
+++ b/hrms/patches/post_install/move_payroll_setting_separately_from_hr_settings.py
@@ -3,28 +3,31 @@
 
 
 import frappe
+from frappe.query_builder import DocType
 
 
 def execute():
-    data = frappe.db.sql(
-        """SELECT *
-        FROM `tabSingles`
-        WHERE
-            doctype = 'HR Settings'
-        AND
-            field IN (
-                'encrypt_salary_slips_in_emails',
-                'email_salary_slip_to_employee',
-                'daily_wages_fraction_for_half_day',
-                'disable_rounded_total',
-                'include_holidays_in_total_working_days',
-                'max_working_hours_against_timesheet',
-                'payroll_based_on',
-                'password_policy'
-            )
-        """,
-        as_dict=1,
-    )
+	singles = DocType("Singles")
+	data = (
+		frappe.qb.from_(singles)
+		.select("*")
+		.where(singles.doctype == "HR Settings")
+		.where(
+			singles.field.isin(
+				[
+					"encrypt_salary_slips_in_emails",
+					"email_salary_slip_to_employee",
+					"daily_wages_fraction_for_half_day",
+					"disable_rounded_total",
+					"include_holidays_in_total_working_days",
+					"max_working_hours_against_timesheet",
+					"payroll_based_on",
+					"password_policy",
+				]
+			)
+		)
+		.run(as_dict=True)
+	)
 
-    for d in data:
-        frappe.db.set_value("Payroll Settings", None, d.field, d.value)
+	for d in data:
+		frappe.db.set_value("Payroll Settings", None, d.field, d.value)

--- a/hrms/payroll/doctype/employee_benefit_claim/employee_benefit_claim.py
+++ b/hrms/payroll/doctype/employee_benefit_claim/employee_benefit_claim.py
@@ -1,250 +1,251 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
-
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import flt
+from frappe.utils import get_link_to_form, getdate
 
-from hrms.hr.utils import get_previous_claimed_amount, validate_active_employee
-from hrms.payroll.doctype.employee_benefit_application.employee_benefit_application import (
-	get_max_benefits,
-)
 from hrms.payroll.doctype.payroll_period.payroll_period import get_payroll_period
+from hrms.payroll.doctype.salary_slip.salary_slip import get_benefits_details_parent
 from hrms.payroll.doctype.salary_structure_assignment.salary_structure_assignment import (
 	get_assigned_salary_structure,
 )
 
 
 class EmployeeBenefitClaim(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		amended_from: DF.Link | None
+		attachments: DF.Attach | None
+		claimed_amount: DF.Currency
+		company: DF.Link
+		currency: DF.Link
+		department: DF.Link | None
+		earning_component: DF.Link
+		employee: DF.Link
+		employee_name: DF.Data | None
+		max_amount_eligible: DF.Currency
+		payroll_date: DF.Date
+		yearly_benefit: DF.Currency
+	# end: auto-generated types
+
 	def validate(self):
-		validate_active_employee(self.employee)
-		max_benefits = get_max_benefits(self.employee, self.claim_date)
-		if not max_benefits or max_benefits <= 0:
-			frappe.throw(_("Employee {0} has no maximum benefit amount").format(self.employee))
-		payroll_period = get_payroll_period(
-			self.claim_date, self.claim_date, frappe.db.get_value("Employee", self.employee, "company")
-		)
-		if not payroll_period:
-			frappe.throw(
-				_("{0} is not in a valid Payroll Period").format(
-					frappe.format(self.claim_date, dict(fieldtype="Date"))
-				)
-			)
-		self.validate_max_benefit_for_component(payroll_period)
-		self.validate_max_benefit_for_sal_struct(max_benefits)
-		self.validate_benefit_claim_amount(max_benefits, payroll_period)
-		if self.pay_against_benefit_claim:
-			self.validate_non_pro_rata_benefit_claim(max_benefits, payroll_period)
+		self.validate_date_and_benefit_claim_amount()
+		self.validate_duplicate_claim()
 
-	def validate_benefit_claim_amount(self, max_benefits, payroll_period):
-		claimed_amount = self.claimed_amount
-		claimed_amount += get_previous_claimed_amount(self.employee, payroll_period)
-		if max_benefits < claimed_amount:
+	def validate_date_and_benefit_claim_amount(self):
+		if getdate(self.payroll_date) < getdate():
 			frappe.throw(
 				_(
-					"Maximum benefit of employee {0} exceeds {1} by the sum {2} of previous claimed amount"
-				).format(self.employee, max_benefits, claimed_amount - max_benefits)
-			)
-
-	def validate_max_benefit_for_sal_struct(self, max_benefits):
-		if self.claimed_amount > max_benefits:
-			frappe.throw(
-				_("Maximum benefit amount of employee {0} exceeds {1}").format(self.employee, max_benefits)
-			)
-
-	def validate_max_benefit_for_component(self, payroll_period):
-		if self.max_amount_eligible:
-			claimed_amount = self.claimed_amount
-			claimed_amount += get_previous_claimed_amount(
-				self.employee, payroll_period, component=self.earning_component
-			)
-			if claimed_amount > self.max_amount_eligible:
-				frappe.throw(
-					_("Maximum amount eligible for the component {0} exceeds {1}").format(
-						self.earning_component, self.max_amount_eligible
-					)
+					"Payroll date cannot be in the past. This is to ensure that claims are made for the current or future payroll cycles."
 				)
+			)
 
-	def validate_non_pro_rata_benefit_claim(self, max_benefits, payroll_period):
-		claimed_amount = self.claimed_amount
-		pro_rata_amount = self.get_pro_rata_amount_in_application(payroll_period.name)
-		if not pro_rata_amount:
-			pro_rata_amount = 0
-			# Get pro_rata_amount if there is no application,
-			# get salary structure for the date and calculate pro-rata amount
-			sal_struct_name = get_assigned_salary_structure(self.employee, self.claim_date)
-			if sal_struct_name:
-				sal_struct = frappe.get_doc("Salary Structure", sal_struct_name)
-				pro_rata_amount = get_benefit_pro_rata_ratio_amount(
-					self.employee, self.claim_date, sal_struct
-				)
+		if self.claimed_amount <= 0:
+			frappe.throw(_("Claimed amount of employee {0} should be greater than 0").format(self.employee))
 
-		claimed_amount += get_previous_claimed_amount(self.employee, payroll_period, non_pro_rata=True)
-		if max_benefits < pro_rata_amount + claimed_amount:
+		if self.claimed_amount > self.max_amount_eligible:
 			frappe.throw(
-				_(
-					"Maximum benefit of employee {0} exceeds {1} by the sum {2} of benefit application pro-rata component amount and previous claimed amount"
-				).format(self.employee, max_benefits, pro_rata_amount + claimed_amount - max_benefits)
+				_("Claimed amount of employee {0} exceeds maximum amount eligible for claim {1}").format(
+					self.employee, self.max_amount_eligible
+				)
 			)
 
-	def get_pro_rata_amount_in_application(self, payroll_period):
-		application = frappe.db.exists(
-			"Employee Benefit Application",
-			{"employee": self.employee, "payroll_period": payroll_period, "docstatus": 1},
-		)
-		if application:
-			return frappe.db.get_value(
-				"Employee Benefit Application", application, "pro_rata_dispensed_amount"
+	def validate_duplicate_claim(self):
+		"""
+		Since Employee Benefit Ledger entries are only created upon Salary Slip submission,
+		there is a risk of multiple claims being created for the same benefit component within
+		one payroll cycle, and combined claim amount exceeding the maximum eligible amount.
+		So limit the claim to one per month.
+		"""
+		existing_claim = self.get_existing_claim_for_month()
+		if existing_claim:
+			msg = _(
+				"Employee {0} has already claimed the benefit '{1}' for {2} ({3}).<br>"
+				"To prevent overpayments, only one claim per benefit type is allowed in each payroll cycle."
+			).format(
+				frappe.bold(self.employee),
+				frappe.bold(self.earning_component),
+				frappe.bold(frappe.utils.formatdate(self.payroll_date, "MMMM yyyy")),
+				frappe.bold(get_link_to_form("Employee Benefit Claim", existing_claim)),
 			)
-		return False
+			frappe.throw(msg, title=_("Duplicate Claim Detected"))
 
+	def on_submit(self):
+		self.create_additional_salary()
 
-def get_benefit_pro_rata_ratio_amount(employee, on_date, sal_struct):
-	total_pro_rata_max = 0
-	benefit_amount_total = 0
-	for sal_struct_row in sal_struct.get("earnings"):
-		try:
-			pay_against_benefit_claim, max_benefit_amount = frappe.get_cached_value(
-				"Salary Component",
-				sal_struct_row.salary_component,
-				["pay_against_benefit_claim", "max_benefit_amount"],
-			)
-		except TypeError:
-			# show the error in tests?
-			frappe.throw(_("Unable to find Salary Component {0}").format(sal_struct_row.salary_component))
+	def get_existing_claim_for_month(self):
+		month_start_date = frappe.utils.get_first_day(self.payroll_date)
+		month_end_date = frappe.utils.get_last_day(self.payroll_date)
 
-		if sal_struct_row.is_flexible_benefit == 1 and pay_against_benefit_claim != 1:
-			total_pro_rata_max += max_benefit_amount
-
-	if total_pro_rata_max > 0:
-		for sal_struct_row in sal_struct.get("earnings"):
-			pay_against_benefit_claim, max_benefit_amount = frappe.get_cached_value(
-				"Salary Component",
-				sal_struct_row.salary_component,
-				["pay_against_benefit_claim", "max_benefit_amount"],
-			)
-
-			if sal_struct_row.is_flexible_benefit == 1 and pay_against_benefit_claim != 1:
-				component_max = max_benefit_amount
-				benefit_amount = component_max * sal_struct.max_benefits / total_pro_rata_max
-				if benefit_amount > component_max:
-					benefit_amount = component_max
-				benefit_amount_total += benefit_amount
-	return benefit_amount_total
-
-
-def get_benefit_claim_amount(employee, start_date, end_date, salary_component=None):
-	query = """
-		select sum(claimed_amount)
-		from `tabEmployee Benefit Claim`
-		where
-			employee=%(employee)s
-			and docstatus = 1
-			and pay_against_benefit_claim = 1
-			and claim_date between %(start_date)s and %(end_date)s
-	"""
-
-	if salary_component:
-		query += " and earning_component = %(earning_component)s"
-
-	claimed_amount = flt(
-		frappe.db.sql(
-			query,
+		return frappe.db.get_value(
+			"Employee Benefit Claim",
 			{
-				"employee": employee,
-				"start_date": start_date,
-				"end_date": end_date,
-				"earning_component": salary_component,
+				"employee": self.employee,
+				"earning_component": self.earning_component,
+				"payroll_date": ["between", [month_start_date, month_end_date]],
+				"docstatus": 1,
+				"name": ["!=", self.name],
 			},
-		)[0][0]
-	)
-
-	return claimed_amount
-
-
-def get_total_benefit_dispensed(employee, sal_struct, sal_slip_start_date, payroll_period):
-	pro_rata_amount = 0
-	claimed_amount = 0
-	application = frappe.db.exists(
-		"Employee Benefit Application",
-		{"employee": employee, "payroll_period": payroll_period.name, "docstatus": 1},
-	)
-	if application:
-		application_obj = frappe.get_cached_value(
-			"Employee Benefit Application",
-			application,
-			["pro_rata_dispensed_amount", "max_benefits", "remaining_benefit"],
-			as_dict=True,
+			"name",
 		)
 
-		pro_rata_amount = (
-			application_obj.pro_rata_dispensed_amount
-			+ application_obj.max_benefits
-			- application_obj.remaining_benefit
+	def create_additional_salary(self):
+		frappe.get_doc(
+			{
+				"doctype": "Additional Salary",
+				"company": self.company,
+				"employee": self.employee,
+				"currency": self.currency,
+				"salary_component": self.earning_component,
+				"payroll_date": self.payroll_date,
+				"amount": self.claimed_amount,
+				"overwrite_salary_structure_amount": 0,
+				"ref_doctype": self.doctype,
+				"ref_docname": self.name,
+			}
+		).submit()
+
+	@frappe.whitelist()
+	def get_benefit_details(self) -> None:
+		# Fetch max benefit amount and claimable amount for the employee based on the earning component chosen
+		from hrms.payroll.doctype.employee_benefit_ledger.employee_benefit_ledger import (
+			get_max_claim_eligible,
 		)
-	else:
-		pro_rata_amount = get_benefit_pro_rata_ratio_amount(employee, sal_slip_start_date, sal_struct)
 
-	claimed_amount += get_benefit_claim_amount(employee, payroll_period.start_date, payroll_period.end_date)
+		payroll_period = get_payroll_period(self.payroll_date, self.payroll_date, self.company).get("name")
+		salary_structure_assignment = get_salary_structure_assignment(self.employee, self.payroll_date)
+		component_details = self.get_component_details(payroll_period, salary_structure_assignment)
 
-	return claimed_amount + pro_rata_amount
+		yearly_benefit = 0
+		claimable_benefit = 0
+
+		if component_details:
+			current_month_amount = self._get_current_month_benefit_amount(component_details)
+			yearly_benefit = component_details.get("amount", 0)
+			claimable_benefit = get_max_claim_eligible(
+				self.employee, payroll_period, component_details, current_month_amount
+			)
+
+		self.yearly_benefit = yearly_benefit
+		self.max_amount_eligible = claimable_benefit
+
+	def get_component_details(self, payroll_period, salary_structure_assignment):
+		# Get component details from benefit parent document
+		benefit_details_parent, benefit_details_doctype = get_benefits_details_parent(
+			self.employee, payroll_period, salary_structure_assignment
+		)
+
+		if not benefit_details_parent:
+			return None
+
+		EmployeeBenefitDetail = frappe.qb.DocType(benefit_details_doctype)
+		SalaryComponent = frappe.qb.DocType("Salary Component")
+
+		component_details = (
+			frappe.qb.from_(EmployeeBenefitDetail)
+			.join(SalaryComponent)
+			.on(SalaryComponent.name == EmployeeBenefitDetail.salary_component)
+			.select(
+				SalaryComponent.name,
+				SalaryComponent.payout_method,
+				SalaryComponent.depends_on_payment_days,
+				EmployeeBenefitDetail.amount,
+			)
+			.where(SalaryComponent.name == self.earning_component)
+			.where(EmployeeBenefitDetail.parent == benefit_details_parent)
+		).run(as_dict=True)
+
+		return component_details[0] if component_details else None
+
+	def _get_current_month_benefit_amount(self, component_details: dict) -> float:
+		# Get current month benefit amount if payout method requires it
+		payout_method = component_details.get("payout_method")
+		if payout_method == "Accrue per cycle, pay only on claim":
+			return self.preview_salary_slip_and_fetch_current_month_benefit_amount()
+		return 0.0
+
+	def preview_salary_slip_and_fetch_current_month_benefit_amount(self):
+		"""Preview salary slip and fetch current month benefit amount for accrual components."""
+		from hrms.payroll.doctype.salary_structure.salary_structure import make_salary_slip
+
+		salary_structure = get_assigned_salary_structure(self.employee, self.payroll_date)
+		salary_slip = make_salary_slip(
+			salary_structure, employee=self.employee, posting_date=self.payroll_date, for_preview=1
+		)
+		accrued_benefits = salary_slip.get("accrued_benefits", [])
+		for benefit in accrued_benefits:
+			if benefit.get("salary_component") == self.earning_component:
+				return benefit.get("amount", 0)
+		return 0
 
 
-def get_last_payroll_period_benefits(
-	employee, sal_slip_start_date, sal_slip_end_date, payroll_period, sal_struct
-):
-	if sal_struct:
-		max_benefits = sal_struct.max_benefits
-	else:
-		max_benefits = get_max_benefits(employee, payroll_period.end_date)
+@frappe.whitelist()
+def get_benefit_components(
+	doctype: str, txt: str, searchfield: str, start: int, page_len: int, filters: dict
+) -> list:
+	"""Fetch benefit components to choose from based on employee and date filters."""
+	frappe.has_permission("Employee", "read", filters.get("employee"), throw=True)
+	employee = filters.get("employee")
+	date = filters.get("date")
+	company = filters.get("company")
 
-	remaining_benefit = max_benefits - get_total_benefit_dispensed(
-		employee, sal_struct, sal_slip_start_date, payroll_period
-	)
+	if not employee or not date:
+		return []
 
-	if remaining_benefit > 0:
-		have_remaining = True
-		# Set the remaining benefits to flexi non pro-rata component in the salary structure
-		salary_components_array = []
-		for d in sal_struct.get("earnings"):
-			if d.is_flexible_benefit == 1:
-				salary_component = frappe.get_cached_doc("Salary Component", d.salary_component)
-				if salary_component.pay_against_benefit_claim == 1:
-					claimed_amount = get_benefit_claim_amount(
-						employee, payroll_period.start_date, sal_slip_end_date, d.salary_component
-					)
-					amount_fit_to_component = salary_component.max_benefit_amount - claimed_amount
-					if amount_fit_to_component > 0:
-						if remaining_benefit > amount_fit_to_component:
-							amount = amount_fit_to_component
-							remaining_benefit -= amount_fit_to_component
-						else:
-							amount = remaining_benefit
-							have_remaining = False
-						current_claimed_amount = get_benefit_claim_amount(
-							employee, sal_slip_start_date, sal_slip_end_date, d.salary_component
-						)
-						amount += current_claimed_amount
-						struct_row = {}
-						salary_components_dict = {}
-						struct_row["depends_on_payment_days"] = salary_component.depends_on_payment_days
-						struct_row["salary_component"] = salary_component.name
-						struct_row["abbr"] = salary_component.salary_component_abbr
-						struct_row["do_not_include_in_total"] = salary_component.do_not_include_in_total
-						struct_row["is_tax_applicable"] = (salary_component.is_tax_applicable,)
-						struct_row["is_flexible_benefit"] = (salary_component.is_flexible_benefit,)
-						struct_row["variable_based_on_taxable_salary"] = (
-							salary_component.variable_based_on_taxable_salary
-						)
-						salary_components_dict["amount"] = amount
-						salary_components_dict["struct_row"] = struct_row
-						salary_components_array.append(salary_components_dict)
-			if not have_remaining:
-				break
+	try:
+		salary_structure_assignment = get_salary_structure_assignment(employee, date)
+		payroll_period = get_payroll_period(date, date, company).get("name")
 
-		if len(salary_components_array) > 0:
-			return salary_components_array
+		benefit_details_parent, benefit_details_doctype = get_benefits_details_parent(
+			employee, payroll_period, salary_structure_assignment
+		)
 
-	return False
+		if not benefit_details_parent:
+			return []
+
+		SalaryComponent = frappe.qb.DocType("Salary Component")
+		EmployeeBenefitDetail = frappe.qb.DocType(benefit_details_doctype)
+		return (
+			frappe.qb.from_(EmployeeBenefitDetail)
+			.join(SalaryComponent)
+			.on(SalaryComponent.name == EmployeeBenefitDetail.salary_component)
+			.select(EmployeeBenefitDetail.salary_component)
+			.where(EmployeeBenefitDetail.parent == benefit_details_parent)
+			.where(
+				SalaryComponent.payout_method.isin(
+					["Accrue per cycle, pay only on claim", "Allow claim for full benefit amount"]
+				)
+			)
+		).run()
+
+	except Exception as e:
+		frappe.log_error("Error fetching benefit components", e)
+		return []
+
+
+def get_salary_structure_assignment(employee, date):
+	SalaryStructureAssignment = frappe.qb.DocType("Salary Structure Assignment")
+	result = (
+		frappe.qb.from_(SalaryStructureAssignment)
+		.select(SalaryStructureAssignment.name)
+		.where(SalaryStructureAssignment.employee == employee)
+		.where(SalaryStructureAssignment.docstatus == 1)
+		.where(SalaryStructureAssignment.from_date <= date)
+		.orderby(SalaryStructureAssignment.from_date, order=frappe.qb.desc)
+		.limit(1)
+	).run(pluck="name")
+
+	if not result:
+		frappe.throw(
+			_("Salary Structure Assignment not found for employee {0} on date {1}").format(employee, date)
+		)
+
+	return result[0]

--- a/hrms/payroll/doctype/employee_incentive/employee_incentive.js
+++ b/hrms/payroll/doctype/employee_incentive/employee_incentive.js
@@ -47,7 +47,8 @@ frappe.ui.form.on("Employee Incentive", {
 		if (!frm.doc.company) return;
 		frm.set_query("salary_component", function () {
 			return {
-				filters: { type: "earning", company: frm.doc.company },
+				filters: { component_type: "Earning", company: frm.doc.company },
+				query: "hrms.payroll.doctype.salary_structure.salary_structure.get_salary_component",
 			};
 		});
 	},

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -4,7 +4,7 @@
 from dateutil.relativedelta import relativedelta
 
 import frappe
-from frappe.tests.utils import FrappeTestCase, change_settings
+from frappe.query_builder.functions import Coalesce, Sum
 from frappe.utils import add_days, add_months, cstr, date_diff, flt
 
 import erpnext
@@ -13,10 +13,6 @@ from erpnext.setup.doctype.employee.test_employee import make_employee
 
 from hrms.hr.doctype.employee_advance.employee_advance import (
 	create_return_through_additional_salary,
-)
-from hrms.hr.doctype.employee_advance.test_employee_advance import (
-	make_employee_advance,
-	make_journal_entry_for_advance,
 )
 from hrms.payroll.doctype.payroll_entry.payroll_entry import (
 	PayrollEntry,
@@ -37,33 +33,18 @@ from hrms.payroll.doctype.salary_structure.test_salary_structure import (
 	make_salary_structure,
 )
 from hrms.tests.test_utils import create_department
+from hrms.tests.utils import HRMSTestSuite
 from hrms.utils import get_date_range
 
-test_dependencies = ["Holiday List"]
 
-
-class TestPayrollEntry(FrappeTestCase):
+class TestPayrollEntry(HRMSTestSuite):
 	def setUp(self):
-		for dt in [
-			"Salary Slip",
-			"Salary Detail",
-			"Salary Component",
-			"Salary Component Account",
-			"Payroll Entry",
-			"Salary Structure",
-			"Salary Structure Assignment",
-			"Employee Cost Center",
-			"Payroll Employee Detail",
-			"Additional Salary",
-		]:
-			frappe.db.delete(dt)
-
 		make_earning_salary_component(setup=True, company_list=["_Test Company"])
 		make_deduction_salary_component(setup=True, test_tax=False, company_list=["_Test Company"])
 
 		frappe.db.set_value("Company", "_Test Company", "default_holiday_list", "_Test Holiday List")
 		frappe.db.set_single_value("Payroll Settings", "email_salary_slip_to_employee", 0)
-
+		frappe.db.set_value("Account", "Employee Advances - _TC", "account_type", "Receivable")
 		# set default payable account
 		default_account = frappe.db.get_value("Company", "_Test Company", "default_payroll_payable_account")
 		if not default_account or default_account != "_Test Payroll Payable - _TC":
@@ -77,6 +58,13 @@ class TestPayrollEntry(FrappeTestCase):
 				"Company", "_Test Company", "default_payroll_payable_account", "_Test Payroll Payable - _TC"
 			)
 
+		payroll_account = frappe.get_doc("Account", "_Test Payroll Payable - _TC")
+		if payroll_account and payroll_account.account_type != "Payable":
+			frappe.db.set_value("Account", "_Test Payroll Payable - _TC", "account_type", "Payable")
+
+		if "lending" in frappe.get_installed_apps():
+			frappe.db.set_value("Company", "_Test Company", "loan_accrual_frequency", "Monthly")
+
 	def test_payroll_entry(self):
 		company = frappe.get_doc("Company", "_Test Company")
 		employee = frappe.db.get_value("Employee", {"company": "_Test Company"})
@@ -89,6 +77,7 @@ class TestPayrollEntry(FrappeTestCase):
 			payable_account=company.default_payroll_payable_account,
 			currency=company.default_currency,
 			company=company.name,
+			cost_center="Main - _TC",
 		)
 
 	def test_multi_currency_payroll_entry(self):
@@ -122,23 +111,25 @@ class TestPayrollEntry(FrappeTestCase):
 			self.assertEqual(salary_slip.base_gross_pay, payroll_je_doc.total_debit)
 			self.assertEqual(salary_slip.base_gross_pay, payroll_je_doc.total_credit)
 
-		payment_entry = frappe.db.sql(
-			"""
-			select
-				ifnull(sum(je.total_debit),0) as total_debit,
-				ifnull(sum(je.total_credit),0) as total_credit
-			from `tabJournal Entry` je, `tabJournal Entry Account` jea
-			where je.name = jea.parent
-				and je.voucher_type = 'Bank Entry'
-				and jea.reference_name = %s
-			""",
-			payroll_entry.name,
-			as_dict=1,
-		)
+		je = frappe.qb.DocType("Journal Entry")
+		jea = frappe.qb.DocType("Journal Entry Account")
+		payment_entry = (
+			frappe.qb.from_(je)
+			.from_(jea)
+			.select(
+				Coalesce(Sum(je.total_debit), 0).as_("total_debit"),
+				Coalesce(Sum(je.total_credit), 0).as_("total_credit"),
+			)
+			.where(je.name == jea.parent)
+			.where((je.voucher_type == "Bank Entry") | (je.voucher_type == "Cash Entry"))
+			.where(jea.reference_name == payroll_entry.name)
+		).run(as_dict=1)
 		self.assertEqual(salary_slip.base_net_pay, payment_entry[0].total_debit)
 		self.assertEqual(salary_slip.base_net_pay, payment_entry[0].total_credit)
 
-	@change_settings("Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 0})
+	@HRMSTestSuite.change_settings(
+		"Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 0}
+	)
 	def test_payroll_entry_with_employee_cost_center(self):
 		department = create_department("Cost Center Test")
 
@@ -164,15 +155,14 @@ class TestPayrollEntry(FrappeTestCase):
 			cost_center="Main - _TC",
 		)
 		je = frappe.db.get_value("Salary Slip", {"payroll_entry": pe.name}, "journal_entry")
-		je_entries = frappe.db.sql(
-			"""
-			select account, cost_center, debit, credit
-			from `tabJournal Entry Account`
-			where parent=%s
-			order by account, cost_center
-		""",
-			je,
-		)
+		jea = frappe.qb.DocType("Journal Entry Account")
+		je_entries = (
+			frappe.qb.from_(jea)
+			.select(jea.account, jea.cost_center, jea.debit, jea.credit)
+			.where(jea.parent == je)
+			.orderby(jea.account)
+			.orderby(jea.cost_center)
+		).run()
 		expected_je = (
 			("_Test Payroll Payable - _TC", "Main - _TC", 0.0, 155600.0),
 			("Salary - _TC", "_Test Cost Center - _TC", 124800.0, 0.0),
@@ -183,7 +173,9 @@ class TestPayrollEntry(FrappeTestCase):
 
 		self.assertEqual(je_entries, expected_je)
 
-	@change_settings("Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 0})
+	@HRMSTestSuite.change_settings(
+		"Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 0}
+	)
 	def test_employee_cost_center_breakup(self):
 		"""Test only the latest salary structure assignment is considered for cost center breakup"""
 		COMPANY = "_Test Company"
@@ -245,7 +237,9 @@ class TestPayrollEntry(FrappeTestCase):
 		self.assertEqual(get_end_date("2017-02-15", "daily"), {"end_date": "2017-02-15"})
 
 	@if_lending_app_installed
-	@change_settings("Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 1})
+	@HRMSTestSuite.change_settings(
+		"Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 1}
+	)
 	def test_loan_with_settings_enabled(self):
 		from lending.loan_management.doctype.loan.test_loan import make_loan_disbursement_entry
 
@@ -291,7 +285,9 @@ class TestPayrollEntry(FrappeTestCase):
 		self.assertEqual(party, applicant)
 
 	@if_lending_app_installed
-	@change_settings("Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 0})
+	@HRMSTestSuite.change_settings(
+		"Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 0}
+	)
 	def test_loan_with_settings_disabled(self):
 		from lending.loan_management.doctype.loan.test_loan import make_loan_disbursement_entry
 
@@ -385,9 +381,10 @@ class TestPayrollEntry(FrappeTestCase):
 		self.assertIsNotNone(payroll_entry.error_message)
 
 		frappe.db.set_value("Employee", employee, "status", "Active")
+
+		payroll_entry.create_salary_slips()
 		payroll_entry.submit()
 		payroll_entry.submit_salary_slips()
-
 		payroll_entry.reload()
 		self.assertEqual(payroll_entry.status, "Failed")
 		self.assertIsNotNone(payroll_entry.error_message)
@@ -397,6 +394,9 @@ class TestPayrollEntry(FrappeTestCase):
 			set_salary_component_account(data, company_list=[company])
 
 		# Payroll Entry successful, status should change to Submitted
+
+		payroll_entry.create_salary_slips()
+		payroll_entry.submit()
 		payroll_entry.submit_salary_slips()
 		payroll_entry.reload()
 
@@ -439,6 +439,41 @@ class TestPayrollEntry(FrappeTestCase):
 		# 2 cancelled JVs
 		journal_entries = get_linked_journal_entries(payroll_entry.name, docstatus=2)
 		self.assertEqual(len(journal_entries), 2)
+
+	def test_payroll_entry_cancellation_with_hr_manager(self):
+		company_doc = frappe.get_doc("Company", "_Test Company")
+		employee = make_employee("test_hr_manager_employee@payroll.com", company=company_doc.name)
+
+		setup_salary_structure(employee, company_doc)
+		dates = get_start_end_dates("Monthly", nowdate())
+		payroll_entry = make_payroll_entry(
+			start_date=dates.start_date,
+			end_date=dates.end_date,
+			payable_account=company_doc.default_payroll_payable_account,
+			currency=company_doc.default_currency,
+			company=company_doc.name,
+			cost_center="Main - _TC",
+			payment_account="Cash - _TC",
+		)
+
+		hr_user = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": "test_hr_manager@payroll.com",
+				"first_name": "Test HR Manager",
+				"enabled": 1,
+			}
+		).insert(ignore_if_duplicate=True)
+		hr_user.add_roles("HR Manager")
+		frappe.set_user(hr_user.name)
+
+		payroll_entry.submit()
+		self.assertEqual(payroll_entry.status, "Submitted")
+
+		payroll_entry.cancel()
+		self.assertEqual(payroll_entry.status, "Cancelled")
+
+		frappe.set_user("Administrator")
 
 	def test_payroll_entry_status(self):
 		company_doc = frappe.get_doc("Company", "_Test Company")
@@ -495,7 +530,9 @@ class TestPayrollEntry(FrappeTestCase):
 		payroll_entry.cancel()
 		self.assertEqual(payroll_entry.status, "Cancelled")
 
-	@change_settings("Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 1})
+	@HRMSTestSuite.change_settings(
+		"Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 1}
+	)
 	def test_payroll_accrual_journal_entry_with_employee_tagging(self):
 		company_doc = frappe.get_doc("Company", "_Test Company")
 		employee = make_employee(
@@ -526,7 +563,9 @@ class TestPayrollEntry(FrappeTestCase):
 					self.assertEqual(account.party_type, "Employee")
 					self.assertEqual(account.party, employee)
 
-	@change_settings("Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 0})
+	@HRMSTestSuite.change_settings(
+		"Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 0}
+	)
 	def test_payroll_accrual_journal_entry_without_employee_tagging(self):
 		company_doc = frappe.get_doc("Company", "_Test Company")
 		employee = make_employee(
@@ -559,6 +598,11 @@ class TestPayrollEntry(FrappeTestCase):
 					self.assertEqual(account.party, None)
 
 	def test_advance_deduction_in_accrual_journal_entry(self):
+		from hrms.hr.doctype.employee_advance.test_employee_advance import (
+			make_employee_advance,
+			make_payment_entry,
+		)
+
 		company_doc = frappe.get_doc("Company", "_Test Company")
 		employee = make_employee("test_employee@payroll.com", company=company_doc.name)
 
@@ -566,8 +610,7 @@ class TestPayrollEntry(FrappeTestCase):
 
 		# create employee advance
 		advance = make_employee_advance(employee, {"repay_unclaimed_amount_from_salary": 1})
-		journal_entry = make_journal_entry_for_advance(advance)
-		journal_entry.submit()
+		make_payment_entry(advance)
 		advance.reload()
 
 		# return advance through additional salary (deduction)
@@ -615,7 +658,9 @@ class TestPayrollEntry(FrappeTestCase):
 
 		self.assertEqual(deduction_entry, expected_entry)
 
-	@change_settings("Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 1})
+	@HRMSTestSuite.change_settings(
+		"Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 1}
+	)
 	def test_employee_wise_bank_entry_with_cost_centers(self):
 		department = create_department("Cost Center Test")
 		employee1 = make_employee(
@@ -694,6 +739,7 @@ class TestPayrollEntry(FrappeTestCase):
 			payable_account=company.default_payroll_payable_account,
 			currency=company.default_currency,
 			company=company.name,
+			cost_center="Main - _TC",
 		)
 
 		# case 1: validate unmarked attendance
@@ -720,7 +766,7 @@ class TestPayrollEntry(FrappeTestCase):
 		employees = payroll_entry.get_employees_with_unmarked_attendance()
 		self.assertFalse(employees)
 
-	@change_settings(
+	@HRMSTestSuite.change_settings(
 		"Payroll Settings",
 		{
 			"payroll_based_on": "Attendance",
@@ -757,12 +803,16 @@ class TestPayrollEntry(FrappeTestCase):
 		self.assertTrue(journal_entry)
 
 	@if_lending_app_installed
-	@change_settings("Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 0})
+	@HRMSTestSuite.change_settings(
+		"Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 0}
+	)
 	def test_loan_repayment_from_salary(self):
 		self.run_test_for_loan_repayment_from_salary()
 
 	@if_lending_app_installed
-	@change_settings("Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 1})
+	@HRMSTestSuite.change_settings(
+		"Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 1}
+	)
 	def test_loan_repayment_from_salary_with_employee_tagging(self):
 		self.run_test_for_loan_repayment_from_salary()
 
@@ -807,24 +857,84 @@ class TestPayrollEntry(FrappeTestCase):
 		payroll_entry.make_bank_entry()
 		submit_bank_entry(payroll_entry.name)
 
-		bank_entry = frappe.db.sql(
-			"""
-			SELECT je.total_debit, je.total_credit
-			FROM `tabJournal Entry` je
-			INNER JOIN `tabJournal Entry Account` jea ON je.name = jea.parent
-			WHERE je.voucher_type = 'Bank Entry' AND jea.reference_type = 'Payroll Entry' AND jea.reference_name = %s
-			LIMIT 1
-			""",
-			payroll_entry.name,
-			as_dict=True,
-		)
+		je = frappe.qb.DocType("Journal Entry")
+		jea = frappe.qb.DocType("Journal Entry Account")
+		bank_entry = (
+			frappe.qb.from_(je)
+			.inner_join(jea)
+			.on(je.name == jea.parent)
+			.select(je.total_debit, je.total_credit)
+			.where((je.voucher_type == "Bank Entry") | (je.voucher_type == "Cash Entry"))
+			.where(jea.reference_type == "Payroll Entry")
+			.where(jea.reference_name == payroll_entry.name)
+			.limit(1)
+		).run(as_dict=True)
 
 		total_debit = bank_entry[0].get("total_debit", 0)
 		total_credit = bank_entry[0].get("total_credit", 0)
 		self.assertEqual(total_debit, expected_bank_entry_amount)
 		self.assertEqual(total_credit, expected_bank_entry_amount)
 
-	@change_settings("Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 0})
+	@if_lending_app_installed
+	@HRMSTestSuite.change_settings(
+		"Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 0}
+	)
+	def test_loan_repayment_value_date_for_future_payroll(self):
+		from lending.loan_management.doctype.loan.test_loan import make_loan_disbursement_entry
+		from lending.tests.test_utils import create_loan
+
+		frappe.db.delete("Loan")
+		applicant, branch, currency, payroll_payable_account = setup_lending()
+
+		loan = create_loan(
+			applicant,
+			"Car Loan",
+			280000,
+			"Repay Over Number of Periods",
+			20,
+			applicant_type="Employee",
+			posting_date="2026-06-02",
+			repayment_start_date="2026-07-05",
+		)
+		loan.repay_from_salary = 1
+		loan.submit()
+
+		make_loan_disbursement_entry(
+			loan.name,
+			loan.loan_amount,
+			disbursement_date="2026-06-02",
+			repayment_start_date="2026-07-05",
+		)
+
+		# July 2026 payroll — end_date 2026-07-31 covers the 2026-07-05 demand
+		payroll_entry = make_payroll_entry(
+			company="_Test Company",
+			start_date="2026-07-01",
+			end_date="2026-07-31",
+			payable_account=payroll_payable_account,
+			currency=currency,
+			branch=branch,
+			cost_center="Main - _TC",
+			payment_account="Cash - _TC",
+		)
+
+		salary_slip_name = frappe.db.get_value(
+			"Salary Slip", {"payroll_entry": payroll_entry.name, "employee": applicant}, "name"
+		)
+		loan_repayment_name = frappe.db.get_value(
+			"Salary Slip Loan", {"parent": salary_slip_name}, "loan_repayment_entry"
+		)
+
+		lr_value_date, lr_interest_payable = frappe.db.get_value(
+			"Loan Repayment", loan_repayment_name, ["value_date", "interest_payable"]
+		)
+
+		self.assertEqual(getdate(lr_value_date), getdate("2026-07-31"))
+		self.assertGreater(flt(lr_interest_payable), 0)
+
+	@HRMSTestSuite.change_settings(
+		"Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 0}
+	)
 	def test_component_exclusion_from_accounting_entries(self):
 		company = frappe.get_doc("Company", "_Test Company")
 		employee = make_employee("exclude_component_test@payroll.com", company=company.name)
@@ -888,12 +998,178 @@ class TestPayrollEntry(FrappeTestCase):
 		self.assertIn(company.default_payroll_payable_account, accounts)
 		self.assertNotIn("ESIC Payable - _TC", accounts, "ESIC component wrongly included in JE")
 
+	def test_employee_benefits_accruals_in_salary_slip(self):
+		"""Test to verify
+		- employee flexible benefits of accrual payout methods are fetched into salary slip
+		- employee benefit ledger entries are created for each component
+		- accrual earning components are excluded from earnings and added to accrued_benefts instead
+		- additional salary for accrual component is included in totals and benefit ledger entries are created
+		- unclaimed benefits and benefit type of "Accrue and Payout at end of Payroll Perod" are paid out in final month of payroll period
+		"""
+		from hrms.payroll.doctype.salary_slip.test_salary_slip import (
+			create_salary_slips_for_payroll_period,
+			make_payroll_period,
+		)
+
+		frappe.db.set_value("Company", "_Test Company", "default_holiday_list", "_Test Holiday List")
+
+		make_payroll_period(company="_Test Company")
+		emp = make_employee(
+			"test_employee_benefits@salary.com",
+			company="_Test Company",
+			date_of_joining="2021-01-01",
+		)
+		payroll_period = frappe.get_last_doc("Payroll Period", filters={"company": "_Test Company"})
+
+		make_salary_structure(
+			"Test Benefit Accrual",
+			"Monthly",
+			company="_Test Company",
+			employee=emp,
+			payroll_period=payroll_period,
+			base=65000,
+			include_flexi_benefits=True,
+			test_accrual_component=True,
+			test_tax=True,
+		)
+
+		# Create and submit payroll entry for first month of payroll period
+		first_month_start = payroll_period.start_date
+		first_month_end = add_months(first_month_start, 1)
+		company_doc = frappe.get_doc("Company", "_Test Company")
+
+		payroll_entry = make_payroll_entry(
+			start_date=first_month_start,
+			end_date=first_month_end,
+			payable_account=company_doc.default_payroll_payable_account,
+			currency=company_doc.default_currency,
+			company="_Test Company",
+			cost_center="Main - _TC",
+		)
+		salary_slip = frappe.get_doc("Salary Slip", {"payroll_entry": payroll_entry.name})
+
+		# Check if employee benefits have been fetched to accrued benefits table
+		self.assertTrue(salary_slip.accrued_benefits)
+		accrual_payout_methods = [
+			"Accrue and payout at end of payroll period",
+			"Accrue per cycle, pay only on claim",
+		]
+		for benefit in salary_slip.accrued_benefits:
+			if benefit.salary_component != "Accrued Earnings":
+				payout_method = frappe.db.get_value(
+					"Salary Component", benefit.salary_component, "payout_method"
+				)
+				self.assertIn(payout_method, accrual_payout_methods)
+			else:
+				self.assertEqual(benefit.amount, 1000)
+
+		# Check if employee benefit ledger entries have been created for each component
+		for benefit_row in salary_slip.accrued_benefits:
+			self.assertTrue(
+				frappe.db.exists(
+					"Employee Benefit Ledger",
+					{"salary_slip": salary_slip.name, "salary_component": benefit_row.salary_component},
+				)
+			)
+
+		earnings_list = [earning.salary_component for earning in salary_slip.earnings]
+		self.assertNotIn(
+			"Accrued Earnings", earnings_list
+		)  # "Accrued Earnings component should not be in earnings table but in accrued benefits")
+
+		# Check if Employee Benefit Ledger exists for Accrued Earnings Component
+		self.assertTrue(
+			frappe.db.exists(
+				"Employee Benefit Ledger",
+				{"salary_slip": salary_slip.name, "salary_component": "Accrued Earnings"},
+			)
+		)
+
+		# Create additional salary for accrual component for second month of payroll period
+		second_month_start = add_months(first_month_start, 1)
+		second_month_end = add_months(first_month_start, 2)
+
+		additional_salary = frappe.get_doc(
+			{
+				"doctype": "Additional Salary",
+				"employee": emp,
+				"salary_component": "Accrued Earnings",
+				"amount": 1000,
+				"payroll_date": second_month_end,
+				"company": "_Test Company",
+				"overwrite_salary_structure_amount": 0,
+			}
+		)
+		additional_salary.insert()
+		additional_salary.submit()
+
+		next_month_payroll_entry = make_payroll_entry(
+			start_date=second_month_start,
+			end_date=second_month_end,
+			payable_account=company_doc.default_payroll_payable_account,
+			currency=company_doc.default_currency,
+			company="_Test Company",
+			cost_center="Main - _TC",
+		)
+		next_salary_slip = frappe.get_doc("Salary Slip", {"payroll_entry": next_month_payroll_entry.name})
+
+		# Payout against accrual component as additional salary is recorded in Employee Benefit Ledger
+		self.assertTrue(
+			frappe.db.exists(
+				"Employee Benefit Ledger",
+				{
+					"salary_slip": next_salary_slip.name,
+					"salary_component": "Accrued Earnings",
+					"transaction_type": "Payout",
+				},
+			)
+		)
+
+		frappe.db.delete("Salary Slip", {"employee": emp})
+		frappe.db.delete("Employee Benefit Ledger")
+
+		# check if unclaimed benefits and benefit type of "Accrue and Payout at end of Payroll Perod" are paid out in final month of payroll period
+		create_salary_slips_for_payroll_period(emp, "Test Benefit Accrual", payroll_period)
+
+		salary_slip = frappe.get_all(
+			"Salary Slip", filters={"employee": emp}, order_by="posting_date desc", limit=1, pluck="name"
+		)
+		salary_slip = frappe.get_doc("Salary Slip", salary_slip[0])
+		earnings_components = {earning.salary_component: earning.amount for earning in salary_slip.earnings}
+
+		self.assertEqual(
+			earnings_components.get("Internet Reimbursement"),
+			12000,
+		)
+		self.assertEqual(
+			earnings_components.get("Mediclaim Allowance"),
+			24000,
+		)
+
+	def test_status_on_discard(self):
+		company = frappe.get_doc("Company", "_Test Company")
+		employee = frappe.db.get_value("Employee", {"company": "_Test Company"})
+		setup_salary_structure(employee, company)
+
+		dates = get_start_end_dates("Monthly", nowdate())
+		payroll_entry = get_payroll_entry(
+			start_date=dates.start_date,
+			end_date=dates.end_date,
+			payable_account=company.default_payroll_payable_account,
+			currency=company.default_currency,
+			company=company.name,
+			cost_center="Main - _TC",
+		)
+		payroll_entry.discard()
+		payroll_entry.reload()
+		self.assertEqual(payroll_entry.status, "Cancelled")
+
 
 def get_payroll_entry(**args):
 	args = frappe._dict(args)
 
 	payroll_entry: PayrollEntry = frappe.new_doc("Payroll Entry")
-	payroll_entry.company = args.company or erpnext.get_default_company()
+	payroll_entry.company = args.company or "_Test Company"
 	payroll_entry.start_date = args.start_date or "2016-11-01"
 	payroll_entry.end_date = args.end_date or "2016-11-30"
 	payroll_entry.payment_account = get_payment_account()
@@ -914,9 +1190,6 @@ def get_payroll_entry(**args):
 	payroll_entry.fill_employee_details()
 	payroll_entry.insert()
 
-	# Commit so that the first salary slip creation failure does not rollback the Payroll Entry insert.
-	frappe.db.commit()  # nosemgrep
-
 	return payroll_entry
 
 
@@ -933,7 +1206,7 @@ def make_payroll_entry(**args):
 def get_payment_account():
 	return frappe.get_value(
 		"Account",
-		{"account_type": "Cash", "company": erpnext.get_default_company(), "is_group": 0},
+		{"account_type": "Cash", "company": "_Test Company" or "_Test Company", "is_group": 0},
 		"name",
 	)
 
@@ -1020,6 +1293,7 @@ def setup_lending():
 			penalty_income_account="Penalty Income Account - _TC",
 			repayment_schedule_type="Monthly as per repayment start date",
 			collection_offset_sequence_for_standard_asset="Test EMI Based Standard Loan Demand Offset Order",
+			collection_offset_sequence_for_sub_standard_asset="Test EMI Based Standard Loan Demand Offset Order",
 		)
 
 	return (
@@ -1052,17 +1326,21 @@ def create_loan_for_employee(applicant):
 
 
 def get_repayment_party_type(loan):
-	loan_repayment_entry, payroll_payable_account = frappe.db.get_value(
-		"Loan Repayment", {"against_loan": loan}, ["name", "payroll_payable_account"]
+	loan_repayment = frappe.db.get_value(
+		"Loan Repayment", {"against_loan": loan}, ["name", "payroll_payable_account"], as_dict=True
 	)
+	if not loan_repayment:
+		return "", ""
 
-	party_type, party = frappe.db.get_value(
+	return frappe.db.get_value(
 		"GL Entry",
-		{"voucher_no": loan_repayment_entry, "account": payroll_payable_account, "is_cancelled": 0},
+		{
+			"voucher_no": loan_repayment.name,
+			"account": loan_repayment.payroll_payable_account,
+			"is_cancelled": 0,
+		},
 		["party_type", "party"],
-	)
-
-	return party_type, party
+	) or ("", "")
 
 
 def submit_bank_entry(payroll_entry_id):

--- a/hrms/payroll/doctype/salary_component/salary_component.json
+++ b/hrms/payroll/doctype/salary_component/salary_component.json
@@ -23,9 +23,11 @@
   "exempted_from_income_tax",
   "round_to_the_nearest_integer",
   "statistical_component",
+  "accrual_component",
   "do_not_include_in_total",
-  "remove_if_zero_valued",
   "do_not_include_in_accounts",
+  "remove_if_zero_valued",
+  "arrear_component",
   "disabled",
   "section_break_5",
   "accounts",
@@ -39,11 +41,10 @@
   "help",
   "flexible_benefits_tab",
   "is_flexible_benefit",
-  "max_benefit_amount",
+  "payout_method",
+  "final_cycle_accrual_payout",
   "column_break_9",
-  "pay_against_benefit_claim",
-  "only_tax_impact",
-  "create_separate_payment_entry_against_benefit_claim"
+  "max_benefit_amount"
  ],
  "fields": [
   {
@@ -68,7 +69,7 @@
    "fieldtype": "Select",
    "in_standard_filter": 1,
    "label": "Type",
-   "options": "Earning\nDeduction",
+   "options": "Earning\nDeduction\nEmployer Contribution",
    "reqd": 1
   },
   {
@@ -83,10 +84,12 @@
    "fieldname": "depends_on_payment_days",
    "fieldtype": "Check",
    "label": "Depends on Payment Days",
-   "print_hide": 1
+   "print_hide": 1,
+   "read_only_depends_on": "eval:doc.arrear_component && !doc.amount_based_on_formula"
   },
   {
    "default": "0",
+   "depends_on": "eval:doc.type != \"Employer Contribution\"",
    "fieldname": "do_not_include_in_total",
    "fieldtype": "Check",
    "label": "Do Not Include in Total"
@@ -116,6 +119,7 @@
   },
   {
    "default": "0",
+   "depends_on": "eval:doc.type != \"Employer Contribution\"",
    "description": "If enabled, the value specified or calculated in this component will not contribute to the earnings or deductions. However, it's value can be referenced by other components that can be added or deducted. ",
    "fieldname": "statistical_component",
    "fieldtype": "Check",
@@ -123,12 +127,14 @@
   },
   {
    "default": "0",
+   "depends_on": "eval:doc.type != \"Employer Contribution\"",
    "fieldname": "is_flexible_benefit",
    "fieldtype": "Check",
    "label": "Is Flexible Benefit"
   },
   {
    "depends_on": "is_flexible_benefit",
+   "description": "If greater than zero, this sets the maximum benefit amount assignable to any employee",
    "fieldname": "max_benefit_amount",
    "fieldtype": "Currency",
    "label": "Max Benefit Amount (Yearly)"
@@ -136,27 +142,6 @@
   {
    "fieldname": "column_break_9",
    "fieldtype": "Column Break"
-  },
-  {
-   "default": "0",
-   "depends_on": "is_flexible_benefit",
-   "fieldname": "pay_against_benefit_claim",
-   "fieldtype": "Check",
-   "label": "Pay Against Benefit Claim"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:doc.is_flexible_benefit == 1 & doc.create_separate_payment_entry_against_benefit_claim !=1",
-   "fieldname": "only_tax_impact",
-   "fieldtype": "Check",
-   "label": "Only Tax Impact (Cannot Claim But Part of Taxable Income)"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:doc.is_flexible_benefit == 1 & doc.only_tax_impact !=1",
-   "fieldname": "create_separate_payment_entry_against_benefit_claim",
-   "fieldtype": "Check",
-   "label": "Create Separate Payment Entry Against Benefit Claim"
   },
   {
    "default": "0",
@@ -168,7 +153,7 @@
    "search_index": 1
   },
   {
-   "depends_on": "eval:doc.statistical_component != 1",
+   "depends_on": "eval:doc.statistical_component != 1 && doc.type != \"Employer Contribution\"",
    "fieldname": "section_break_5",
    "fieldtype": "Section Break",
    "label": "Accounts"
@@ -259,7 +244,7 @@
   },
   {
    "default": "1",
-   "depends_on": "eval:!doc.statistical_component",
+   "depends_on": "eval:!doc.statistical_component && doc.type != \"Employer Contribution\"",
    "description": "If enabled, the component will not be displayed in the salary slip if the amount is zero",
    "fieldname": "remove_if_zero_valued",
    "fieldtype": "Check",
@@ -272,12 +257,45 @@
    "fieldname": "do_not_include_in_accounts",
    "fieldtype": "Check",
    "label": "Do Not Include in Accounting Entries"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.type != \"Employer Contribution\"",
+   "description": "If enabled, this component will be included in arrear calculations",
+   "fieldname": "arrear_component",
+   "fieldtype": "Check",
+   "label": "Arrear Component",
+   "read_only_depends_on": "variable_based_on_taxable_salary"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.type==\"Earning\"",
+   "description": "If enabled, this component allows to accrue amounts without adding them to earnings. The accrued balance is tracked in the Employee Benefit Ledger and can be paid out later as needed.",
+   "fieldname": "accrual_component",
+   "fieldtype": "Check",
+   "label": "Accrual Component",
+   "read_only_depends_on": "eval:doc.is_flexible_benefit==1;"
+  },
+  {
+   "depends_on": "is_flexible_benefit",
+   "fieldname": "payout_method",
+   "fieldtype": "Select",
+   "label": "Payout Method",
+   "mandatory_depends_on": "is_flexible_benefit",
+   "options": "\nAccrue and payout at end of payroll period\nAccrue per cycle, pay only on claim\nAllow claim for full benefit amount"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:(doc.is_flexible_benefit && doc.payout_method==\"Accrue per cycle, pay only on claim\")",
+   "fieldname": "final_cycle_accrual_payout",
+   "fieldtype": "Check",
+   "label": "Payout Unclaimed Amount in Final Payroll Cycle"
   }
  ],
  "icon": "fa fa-flag",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-27 13:10:33.871355",
+ "modified": "2026-06-08 17:39:39.847210",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Component",
@@ -286,7 +304,6 @@
  "permissions": [
   {
    "create": 1,
-   "delete": 1,
    "email": 1,
    "export": 1,
    "print": 1,
@@ -299,10 +316,23 @@
   {
    "read": 1,
    "role": "Employee"
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "HR Manager",
+   "share": 1,
+   "write": 1
   }
  ],
  "row_format": "Dynamic",
- "sort_field": "modified",
+ "sort_field": "creation",
  "sort_order": "DESC",
- "states": []
+ "states": [],
+ "track_changes": 1
 }

--- a/hrms/payroll/doctype/salary_component/salary_component.py
+++ b/hrms/payroll/doctype/salary_component/salary_component.py
@@ -12,20 +12,55 @@ from hrms.payroll.utils import sanitize_expression
 
 
 class SalaryComponent(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from hrms.payroll.doctype.salary_component_account.salary_component_account import (
+			SalaryComponentAccount,
+		)
+
+		accounts: DF.Table[SalaryComponentAccount]
+		accrual_component: DF.Check
+		amount: DF.Currency
+		amount_based_on_formula: DF.Check
+		arrear_component: DF.Check
+		condition: DF.Code | None
+		deduct_full_tax_on_selected_payroll_date: DF.Check
+		depends_on_payment_days: DF.Check
+		description: DF.SmallText | None
+		disabled: DF.Check
+		do_not_include_in_accounts: DF.Check
+		do_not_include_in_total: DF.Check
+		exempted_from_income_tax: DF.Check
+		final_cycle_accrual_payout: DF.Check
+		formula: DF.Code | None
+		is_flexible_benefit: DF.Check
+		is_income_tax_component: DF.Check
+		is_tax_applicable: DF.Check
+		max_benefit_amount: DF.Currency
+		payout_method: DF.Literal[
+			"",
+			"Accrue and payout at end of payroll period",
+			"Accrue per cycle, pay only on claim",
+			"Allow claim for full benefit amount",
+		]
+		remove_if_zero_valued: DF.Check
+		round_to_the_nearest_integer: DF.Check
+		salary_component: DF.Data
+		salary_component_abbr: DF.Data
+		statistical_component: DF.Check
+		type: DF.Literal["Earning", "Deduction"]
+		variable_based_on_taxable_salary: DF.Check
+	# end: auto-generated types
+
 	def before_validate(self):
 		self._condition, self.condition = self.condition, sanitize_expression(self.condition)
 		self._formula, self.formula = self.formula, sanitize_expression(self.formula)
-
-	def validate(self):
-		self.validate_abbr()
-		self.validate_accounts()
-
-	def on_update(self):
-		# set old values (allowing multiline strings for better readability in the doctype form)
-		if self._condition != self.condition:
-			self.db_set("condition", self._condition)
-		if self._formula != self.formula:
-			self.db_set("formula", self._formula)
 
 	def validate(self):
 		self.validate_abbr()
@@ -46,6 +81,14 @@ class SalaryComponent(Document):
 			TAX_COMPONENTS_BY_COMPANY,
 		)
 
+		frappe.cache().delete_value(SALARY_COMPONENT_VALUES)
+		frappe.cache().delete_value(TAX_COMPONENTS_BY_COMPANY)
+		return super().clear_cache()
+
+	def validate_abbr(self):
+		if not self.salary_component_abbr:
+			self.salary_component_abbr = "".join([c[0] for c in self.salary_component.split()]).upper()
+
 		self.salary_component_abbr = self.salary_component_abbr.strip()
 		self.salary_component_abbr = append_number_if_name_exists(
 			"Salary Component",
@@ -63,8 +106,44 @@ class SalaryComponent(Document):
 				indicator="orange",
 			)
 
+	def validate_accrual_component(self):
+		if self.type != "Earning" and self.accrual_component:
+			frappe.throw(
+				_("Accrual Component can only be set for Earning Salary Components."),
+				title=_("Invalid Accrual Component"),
+			)
+
+		if self.is_flexible_benefit:
+			requires_accrual = self.payout_method in [
+				"Accrue and payout at end of payroll period",
+				"Accrue per cycle, pay only on claim",
+			]
+
+			if requires_accrual and not self.accrual_component:
+				frappe.throw(
+					_(
+						"Accrual Component must be set for Flexible Benefit Salary Components with accrual payout methods."
+					),
+					title=_("Invalid Accrual Component"),
+				)
+
+			if not requires_accrual and self.accrual_component:
+				frappe.throw(
+					_(
+						"Accrual Component can only be set for Flexible Benefit Salary Components with accrual payout methods."
+					),
+					title=_("Invalid Accrual Component"),
+				)
+
+	def valide_arrear_component(self):
+		if self.variable_based_on_taxable_salary and self.arrear_component:
+			frappe.throw(
+				_("Arrear Component cannot be set for Salary Components based on taxable salary."),
+				title=_("Invalid Arrear Component"),
+			)
+
 	@frappe.whitelist()
-	def get_structures_to_be_updated(self):
+	def get_structures_to_be_updated(self) -> list[str]:
 		SalaryStructure = frappe.qb.DocType("Salary Structure")
 		SalaryDetail = frappe.qb.DocType("Salary Detail")
 		return (
@@ -77,11 +156,16 @@ class SalaryComponent(Document):
 		)
 
 	@frappe.whitelist()
-	def update_salary_structures(self, field, value, structures=None):
+	def update_salary_structures(
+		self, field: str, value: str | int | float | None, structures: list | None = None
+	) -> None:
+		is_formula_related = field == "formula"
+
 		if not structures:
 			structures = self.get_structures_to_be_updated()
 
 		for structure in structures:
+			frappe.has_permission("Salary Structure", "write", structure, throw=True)
 			salary_structure = frappe.get_doc("Salary Structure", structure)
 			# this is only used for versioning and we do not want
 			# to make separate db calls by using load_doc_before_save
@@ -92,6 +176,10 @@ class SalaryComponent(Document):
 				(d for d in salary_structure.get(f"{self.type.lower()}s") if d.salary_component == self.name),
 				None,
 			)
+			if is_formula_related:
+				value = value if self.amount_based_on_formula else None
+				salary_detail_row.set("amount_based_on_formula", self.amount_based_on_formula)
+
 			salary_detail_row.set(field, value)
 			salary_structure.db_update_all()
 			salary_structure.flags.updater_reference = {
@@ -100,3 +188,7 @@ class SalaryComponent(Document):
 				"label": _("via Salary Component sync"),
 			}
 			salary_structure.save_version()
+			# db_update_all() does not invalidate cached Salary Structure documents.
+			# Clear the cache so salary slip generation picks up updated formulas
+			# and conditions immediately.
+			salary_structure.clear_cache()

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -2,11 +2,9 @@
 # License: GNU General Public License v3. See license.txt
 
 
-import unicodedata
-from datetime import date
-
 import frappe
 from frappe import _, msgprint
+from frappe.model.document import Document
 from frappe.model.naming import make_autoname
 from frappe.query_builder import Order
 from frappe.query_builder.functions import Count, Sum
@@ -33,15 +31,14 @@ from erpnext.accounts.utils import get_fiscal_year
 from erpnext.setup.doctype.employee.employee import get_holiday_list_for_employee
 from erpnext.utilities.transaction_base import TransactionBase
 
+import hrms
 from hrms.hr.utils import validate_active_employee
 from hrms.payroll.doctype.additional_salary.additional_salary import get_additional_salaries
-from hrms.payroll.doctype.employee_benefit_application.employee_benefit_application import (
-	get_benefit_component_amount,
+from hrms.payroll.doctype.employee_benefit_ledger.employee_benefit_ledger import (
+	create_employee_benefit_ledger_entry,
+	delete_employee_benefit_ledger_entry,
 )
-from hrms.payroll.doctype.employee_benefit_claim.employee_benefit_claim import (
-	get_benefit_claim_amount,
-	get_last_payroll_period_benefits,
-)
+from hrms.payroll.doctype.income_tax_slab.income_tax_slab import calculate_tax_by_tax_slab
 from hrms.payroll.doctype.payroll_entry.payroll_entry import get_salary_withholdings, get_start_end_dates
 from hrms.payroll.doctype.payroll_period.payroll_period import (
 	get_payroll_period,
@@ -53,7 +50,12 @@ from hrms.payroll.doctype.salary_slip.salary_slip_loan_utils import (
 	process_loan_interest_accrual_and_demand,
 	set_loan_repayment,
 )
-from hrms.payroll.utils import sanitize_expression
+from hrms.payroll.utils import (
+	COMPONENT_EVAL_GLOBALS,
+	_safe_eval,
+	get_component_eval_context,
+	throw_error_message,
+)
 from hrms.utils.holiday_list import get_holiday_dates_between
 
 # cache keys
@@ -64,22 +66,95 @@ TAX_COMPONENTS_BY_COMPANY = "tax_components_by_company"
 
 
 class SalarySlip(TransactionBase):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from hrms.payroll.doctype.employee_benefit_detail.employee_benefit_detail import EmployeeBenefitDetail
+		from hrms.payroll.doctype.salary_detail.salary_detail import SalaryDetail
+		from hrms.payroll.doctype.salary_slip_leave.salary_slip_leave import SalarySlipLeave
+		from hrms.payroll.doctype.salary_slip_timesheet.salary_slip_timesheet import SalarySlipTimesheet
+
+		absent_days: DF.Float
+		accrued_benefits: DF.Table[EmployeeBenefitDetail]
+		amended_from: DF.Link | None
+		annual_taxable_amount: DF.Currency
+		bank_account_no: DF.Data | None
+		bank_name: DF.Data | None
+		base_gross_pay: DF.Currency
+		base_gross_year_to_date: DF.Currency
+		base_hour_rate: DF.Currency
+		base_month_to_date: DF.Currency
+		base_net_pay: DF.Currency
+		base_rounded_total: DF.Currency
+		base_total_deduction: DF.Currency
+		base_total_in_words: DF.Data | None
+		base_year_to_date: DF.Currency
+		branch: DF.Link | None
+		company: DF.Link
+		ctc: DF.Currency
+		currency: DF.Link
+		current_month_income_tax: DF.Currency
+		current_payroll_period: DF.Link | None
+		deduct_tax_for_unsubmitted_tax_exemption_proof: DF.Check
+		deductions: DF.Table[SalaryDetail]
+		deductions_before_tax_calculation: DF.Currency
+		department: DF.Link | None
+		designation: DF.Link | None
+		earnings: DF.Table[SalaryDetail]
+		employee: DF.Link
+		employee_name: DF.ReadOnly
+		end_date: DF.Date | None
+		exchange_rate: DF.Float
+		future_income_tax_deductions: DF.Currency
+		gross_pay: DF.Currency
+		gross_year_to_date: DF.Currency
+		hour_rate: DF.Currency
+		income_from_other_sources: DF.Currency
+		income_tax_deducted_till_date: DF.Currency
+		journal_entry: DF.Link | None
+		leave_details: DF.Table[SalarySlipLeave]
+		leave_without_pay: DF.Float
+		letter_head: DF.Link | None
+		mode_of_payment: DF.Literal[None]
+		month_to_date: DF.Currency
+		net_pay: DF.Currency
+		non_taxable_earnings: DF.Currency
+		payment_days: DF.Float
+		payroll_entry: DF.Link | None
+		payroll_frequency: DF.Literal["", "Monthly", "Fortnightly", "Bimonthly", "Weekly", "Daily"]
+		posting_date: DF.Date
+		rounded_total: DF.Currency
+		salary_slip_based_on_timesheet: DF.Check
+		salary_structure: DF.Link
+		salary_withholding: DF.Link | None
+		salary_withholding_cycle: DF.Data | None
+		standard_tax_exemption_amount: DF.Currency
+		start_date: DF.Date | None
+		status: DF.Literal["Draft", "Submitted", "Cancelled", "Withheld"]
+		tax_exemption_declaration: DF.Currency
+		timesheets: DF.Table[SalarySlipTimesheet]
+		total_deduction: DF.Currency
+		total_earnings: DF.Currency
+		total_in_words: DF.Data | None
+		total_income_tax: DF.Currency
+		total_working_days: DF.Float
+		total_working_hours: DF.Float
+		unmarked_days: DF.Float
+		year_to_date: DF.Currency
+	# end: auto-generated types
+
 	def __init__(self, *args, **kwargs):
 		super().__init__(*args, **kwargs)
-		self.series = f"Sal Slip/{self.employee}/.#####"
-		self.whitelisted_globals = {
-			"int": int,
-			"float": float,
-			"long": int,
-			"round": round,
-			"rounded": rounded,
-			"date": date,
-			"getdate": getdate,
-			"get_first_day": get_first_day,
-			"get_last_day": get_last_day,
-			"ceil": ceil,
-			"floor": floor,
-		}
+		self.whitelisted_globals = COMPONENT_EVAL_GLOBALS.copy()
+
+	@property
+	def default_series(self):
+		return f"Sal Slip/{self.employee}/.#####"
 
 	def autoname(self):
 		if not self.has_custom_naming_series:
@@ -185,6 +260,9 @@ class SalarySlip(TransactionBase):
 					alert=True,
 				)
 
+		if self.payroll_period and not self.current_payroll_period:
+			self.current_payroll_period = self.payroll_period.name
+
 	def check_salary_withholding(self):
 		withholding = get_salary_withholdings(self.start_date, self.end_date, self.employee)
 		if withholding:
@@ -221,6 +299,7 @@ class SalarySlip(TransactionBase):
 					self.email_salary_slip()
 
 		self.update_payment_status_for_gratuity_and_leave_encashment()
+		self.create_benefits_ledger_entry()
 
 	def update_payment_status_for_gratuity_and_leave_encashment(self):
 		additional_salary_docs = frappe.db.get_all(
@@ -246,10 +325,21 @@ class SalarySlip(TransactionBase):
 					additional_salary.ref_doctype, additional_salary.ref_docname, "status", status
 				)
 
+	def create_benefits_ledger_entry(self):
+		if self.benefit_ledger_components:
+			args = {
+				"payroll_period": self.payroll_period.name,
+				"benefit_ledger_components": self.benefit_ledger_components,
+				"benefit_details_parent": self.benefit_details_parent,
+				"benefit_details_doctype": self.benefit_details_doctype,
+			}
+			create_employee_benefit_ledger_entry(self, args)
+
 	def on_cancel(self):
 		self.set_status()
 		self.update_status()
 		self.update_payment_status_for_gratuity_and_leave_encashment()
+		delete_employee_benefit_ledger_entry("salary_slip", self.name)
 
 		cancel_loan_repayment_entry(self)
 		self.publish_update()
@@ -268,6 +358,8 @@ class SalarySlip(TransactionBase):
 
 		if not self.has_custom_naming_series:
 			revert_series_if_last(self.default_series, self.name)
+
+		delete_employee_benefit_ledger_entry("salary_slip", self.name)
 
 	def get_status(self):
 		if self.docstatus == 2:
@@ -337,7 +429,7 @@ class SalarySlip(TransactionBase):
 			self.end_date = date_details.end_date
 
 	@frappe.whitelist()
-	def get_emp_and_working_day_details(self):
+	def get_emp_and_working_day_details(self) -> None:
 		"""First time, load all the components from salary structure"""
 		if self.employee:
 			self.set("earnings", [])
@@ -355,32 +447,39 @@ class SalarySlip(TransactionBase):
 			struct = self.check_sal_struct()
 
 			if struct:
-				self.set_salary_structure_doc()
-				self.salary_slip_based_on_timesheet = (
-					self._salary_structure_doc.salary_slip_based_on_timesheet or 0
-				)
-				self.set_time_sheet()
-				self.pull_sal_struct()
+				from hrms.payroll.doctype.salary_structure.salary_structure import make_salary_slip
+
+				timesheet_config = self._get_ssa_doc().get_timesheet_config()
+				self.salary_slip_based_on_timesheet = timesheet_config.based_on_timesheet
+				if self.salary_slip_based_on_timesheet:
+					self._timesheet_component = timesheet_config.timesheet_component
+					self.set_time_sheet()
+					self.add_timesheet_earning_component(timesheet_config)
+				make_salary_slip(self.salary_structure, self)
 
 			process_loan_interest_accrual_and_demand(self)
 
 	def set_time_sheet(self):
-		if self.salary_slip_based_on_timesheet:
-			self.set("timesheets", [])
+		# caller (get_emp_and_working_day_details) gates this on salary_slip_based_on_timesheet
+		self.set("timesheets", [])
 
-			Timesheet = frappe.qb.DocType("Timesheet")
-			timesheets = (
-				frappe.qb.from_(Timesheet)
-				.select(Timesheet.star)
-				.where(
-					(Timesheet.employee == self.employee)
-					& (Timesheet.start_date.between(self.start_date, self.end_date))
-					& ((Timesheet.status == "Submitted") | (Timesheet.status == "Billed"))
+		Timesheet = frappe.qb.DocType("Timesheet")
+		timesheets = (
+			frappe.qb.from_(Timesheet)
+			.select(Timesheet.star)
+			.where(
+				(Timesheet.employee == self.employee)
+				& (Timesheet.start_date.between(self.start_date, self.end_date))
+				& (
+					(Timesheet.status == "Submitted")
+					| (Timesheet.status == "Billed")
+					| (Timesheet.status == "Partially Billed")
 				)
-			).run(as_dict=1)
+			)
+		).run(as_dict=1)
 
-			for data in timesheets:
-				self.append("timesheets", {"time_sheet": data.name, "working_hours": data.total_hours})
+		for data in timesheets:
+			self.append("timesheets", {"time_sheet": data.name, "working_hours": data.total_hours})
 
 	def check_sal_struct(self):
 		ss = frappe.qb.DocType("Salary Structure")
@@ -424,21 +523,34 @@ class SalarySlip(TransactionBase):
 				title=_("Salary Structure Missing"),
 			)
 
-	def pull_sal_struct(self):
-		from hrms.payroll.doctype.salary_structure.salary_structure import make_salary_slip
+	def add_timesheet_earning_component(self, timesheet_config):
+		self.hour_rate = flt(timesheet_config.hour_rate)
+		self.base_hour_rate = flt(self.hour_rate) * flt(self.exchange_rate)
+		self.total_working_hours = sum([d.working_hours or 0.0 for d in self.timesheets]) or 0.0
+		wages_amount = self.hour_rate * self.total_working_hours
 
-		if self.salary_slip_based_on_timesheet:
-			self.salary_structure = self._salary_structure_doc.name
-			self.hour_rate = self._salary_structure_doc.hour_rate
-			self.base_hour_rate = flt(self.hour_rate) * flt(self.exchange_rate)
-			self.total_working_hours = sum([d.working_hours or 0.0 for d in self.timesheets]) or 0.0
+		self.add_earning_for_hourly_wages(self, timesheet_config.timesheet_component, wages_amount)
+
+	def add_earning_for_hourly_wages(self, doc, salary_component, amount):
+		row_exists = False
+		for row in doc.earnings:
+			if row.salary_component == salary_component:
+				row.amount = amount
+				row_exists = True
+				break
+
+		if not row_exists:
+			wages_row = get_salary_component_data(salary_component)
 			wages_amount = self.hour_rate * self.total_working_hours
 
-			self.add_earning_for_hourly_wages(self, self._salary_structure_doc.salary_component, wages_amount)
+			self.update_component_row(
+				wages_row,
+				wages_amount,
+				"earnings",
+				default_amount=wages_amount,
+			)
 
-		make_salary_slip(self._salary_structure_doc.name, self)
-
-	def get_working_days_details(self, lwp=None, for_preview=0):
+	def get_working_days_details(self, lwp=None, for_preview=0, lwp_days_corrected=None):
 		payroll_settings = frappe.get_cached_value(
 			"Payroll Settings",
 			None,
@@ -510,17 +622,25 @@ class SalarySlip(TransactionBase):
 
 			consider_unmarked_attendance_as = payroll_settings.consider_unmarked_attendance_as or "Present"
 
-			if (
-				payroll_settings.payroll_based_on == "Attendance"
-				and consider_unmarked_attendance_as == "Absent"
-			):
-				unmarked_days = self.get_unmarked_days(
-					payroll_settings.include_holidays_in_total_working_days, holidays
+			if payroll_settings.payroll_based_on == "Attendance":
+				if consider_unmarked_attendance_as == "Absent":
+					unmarked_days = self.get_unmarked_days(
+						payroll_settings.include_holidays_in_total_working_days, holidays
+					)
+					self.absent_days += unmarked_days  # will be treated as absent
+					self.payment_days -= unmarked_days
+				half_absent_days = self.get_half_absent_days(
+					consider_marked_attendance_on_holidays,
+					holidays,
 				)
-				self.absent_days += unmarked_days  # will be treated as absent
-				self.payment_days -= unmarked_days
+				self.absent_days += half_absent_days * daily_wages_fraction_for_half_day
+				self.payment_days -= half_absent_days * daily_wages_fraction_for_half_day
 		else:
 			self.payment_days = 0
+
+		if lwp_days_corrected and lwp_days_corrected > 0:
+			if verify_lwp_days_corrected(self.employee, self.start_date, self.end_date, lwp_days_corrected):
+				self.payment_days += lwp_days_corrected
 
 	def get_unmarked_days(
 		self, include_holidays_in_total_working_days: bool, holidays: list | None = None
@@ -772,18 +892,6 @@ class SalarySlip(TransactionBase):
 
 		return lwp, absent
 
-	def add_earning_for_hourly_wages(self, doc, salary_component, amount):
-		row_exists = False
-		for row in doc.earnings:
-			if row.salary_component == salary_component:
-				row.amount = amount
-				row_exists = True
-				break
-
-		if not row_exists:
-			wages_row = get_salary_component_data(salary_component)
-			wages_amount = self.hour_rate * self.total_working_hours
-
 	def set_salary_structure_assignment(self):
 		self._salary_structure_assignment = frappe.db.get_value(
 			"Salary Structure Assignment",
@@ -815,9 +923,6 @@ class SalarySlip(TransactionBase):
 				flt(self.gross_pay) * flt(self.exchange_rate), self.precision("base_gross_pay")
 			)
 
-		if self.salary_structure:
-			self.calculate_component_amounts("earnings")
-
 		# get remaining numbers of sub-period (period for which one salary is processed)
 		if self.payroll_period:
 			self.remaining_sub_periods = get_period_factor(
@@ -830,6 +935,9 @@ class SalarySlip(TransactionBase):
 				relieving_date=self.relieving_date,
 			)[1]
 
+		if self.salary_structure:
+			self.calculate_component_amounts("earnings")
+
 		set_gross_pay_and_base_gross_pay()
 
 		if self.salary_structure:
@@ -837,10 +945,20 @@ class SalarySlip(TransactionBase):
 
 		set_loan_repayment(self)
 
+		# Region-specific deductions (e.g. India statutory deductions) are injected
+		# here so they are reflected in both saved slips and the preview generated
+		# by process_salary_structure, before totals are finalised below.
+		self.apply_regional_deductions()
+
 		self.set_precision_for_component_amounts()
 		self.set_net_pay()
 		if not skip_tax_breakup_computation:
 			self.compute_income_tax_breakup()
+
+	@hrms.allow_regional
+	def apply_regional_deductions(self):
+		"Hook point for region-specific salary slip deductions."
+		pass
 
 	def set_net_pay(self):
 		self.total_deduction = self.get_component_totals("deductions")
@@ -872,12 +990,9 @@ class SalarySlip(TransactionBase):
 		# Deduct taxes forcefully for unsubmitted tax exemption proof and unclaimed benefits in the last period
 		if self.payroll_period.end_date <= getdate(self.end_date):
 			self.deduct_tax_for_unsubmitted_tax_exemption_proof = 1
-			self.deduct_tax_for_unclaimed_employee_benefits = 1
 
 		# Get taxable unclaimed benefits
 		self.unclaimed_taxable_benefits = 0
-		if self.deduct_tax_for_unclaimed_employee_benefits:
-			self.unclaimed_taxable_benefits = self.calculate_unclaimed_taxable_benefits()
 
 		# Total exemption amount based on tax exemption declaration
 		self.total_exemption_amount = self.get_total_exemption_amount()
@@ -905,7 +1020,7 @@ class SalarySlip(TransactionBase):
 		# get taxable_earnings for current period (all days)
 		self.current_taxable_earnings = self.get_taxable_earnings(self.tax_slab.allow_tax_exemption)
 		self.future_structured_taxable_earnings = self.current_taxable_earnings.taxable_earnings * (
-			ceil(self.remaining_sub_periods) - 1
+			round(self.remaining_sub_periods) - 1
 		)
 
 		current_taxable_earnings_before_exemption = (
@@ -913,7 +1028,7 @@ class SalarySlip(TransactionBase):
 			+ self.current_taxable_earnings.amount_exempted_from_income_tax
 		)
 		self.future_structured_taxable_earnings_before_exemption = (
-			current_taxable_earnings_before_exemption * (ceil(self.remaining_sub_periods) - 1)
+			current_taxable_earnings_before_exemption * (round(self.remaining_sub_periods) - 1)
 		)
 
 		# get taxable_earnings, addition_earnings for current actual payment days
@@ -1081,7 +1196,7 @@ class SalarySlip(TransactionBase):
 				current_period_exempted_amount += d.amount
 
 		# Future period exempted amount
-		for deduction in self._salary_structure_doc.get("deductions"):
+		for deduction in self._evaluated_components["deductions"]:
 			if deduction.exempted_from_income_tax:
 				if deduction.amount_based_on_formula:
 					for sub_period in range(1, ceil(self.remaining_sub_periods)):
@@ -1129,52 +1244,91 @@ class SalarySlip(TransactionBase):
 		return tax_deducted
 
 	def calculate_component_amounts(self, component_type):
-		if not getattr(self, "_salary_structure_doc", None):
-			self.set_salary_structure_doc()
+		if component_type == "earnings":
+			self.accrued_benefits = []
+			self.benefit_ledger_components = []
+
+		if not getattr(self, "_evaluated_components", None):
+			self._set_evaluated_components()
 
 		self.add_structure_components(component_type)
 		self.add_additional_salary_components(component_type)
-
 		if component_type == "earnings":
 			self.add_employee_benefits()
 		else:
 			self.add_tax_components()
 
-	def set_salary_structure_doc(self) -> None:
-		self._salary_structure_doc = frappe.get_cached_doc("Salary Structure", self.salary_structure)
-		# sanitize condition and formula fields
-		for table in ("earnings", "deductions"):
-			for row in self._salary_structure_doc.get(table):
-				row.condition = sanitize_expression(row.condition)
-				row.formula = sanitize_expression(row.formula)
+	def _set_evaluated_components(self) -> None:
+		"""Ask the Salary Structure Assignment to evaluate all component formulas
+		once and return fully-resolved rows (with default_amount + flags). Shared
+		across the earnings and deductions passes so cross-component references
+		(e.g. a deduction referencing an earning abbr) resolve correctly."""
+		self._evaluated_components = self._get_ssa_doc().get_evaluated_components()
+
+	def _get_ssa_doc(self):
+		if not getattr(self, "_ssa_doc", None):
+			if not hasattr(self, "_salary_structure_assignment"):
+				self.set_salary_structure_assignment()
+			self._ssa_doc = frappe.get_cached_doc(
+				"Salary Structure Assignment", self._salary_structure_assignment.name
+			)
+		return self._ssa_doc
 
 	def add_structure_components(self, component_type):
 		self.data, self.default_data = self.get_data_for_eval()
 
-		for struct_row in self._salary_structure_doc.get(component_type):
+		for struct_row in self._evaluated_components[component_type]:
 			self.add_structure_component(struct_row, component_type)
 
 	def add_structure_component(self, struct_row, component_type):
-		if (
-			self.salary_slip_based_on_timesheet
-			and struct_row.salary_component == self._salary_structure_doc.salary_component
+		# the timesheet wage component is added separately (hour_rate * hours) in
+		# add_timesheet_earning_component, so skip it here to avoid double-adding
+		if self.salary_slip_based_on_timesheet and struct_row.salary_component == getattr(
+			self, "_timesheet_component", None
 		):
 			return
 
+		# struct_row is a resolved row from the Salary Structure Assignment carrying the
+		# component's formula/condition/flags. The slip evaluates it against its own context:
+		#   - self.data:         payment-days prorated values -> the actual `amount`
+		#   - self.default_data: full-cycle values            -> the `default_amount`
+		# (proration cascades through dependent formulas, e.g. SA = BS * 0.5 inherits BS's proration).
 		amount = self.eval_condition_and_formula(struct_row, self.data)
-		if struct_row.statistical_component:
-			# update statitical component amount in reference data based on payment days
+		if struct_row.statistical_component or struct_row.accrual_component:
+			# update statistical component amount in reference data based on payment days
 			# since row for statistical component is not added to salary slip
-
 			self.default_data[struct_row.abbr] = flt(amount)
 			if struct_row.depends_on_payment_days:
-				payment_days_amount = (
+				amount = (
 					flt(amount) * flt(self.payment_days) / cint(self.total_working_days)
 					if self.total_working_days
 					else 0
 				)
-				self.data[struct_row.abbr] = flt(payment_days_amount, struct_row.precision("amount"))
+				self.data[struct_row.abbr] = flt(amount, struct_row.precision)
 
+			is_accrual_component = (
+				component_type == "earnings"
+				and struct_row.accrual_component
+				and hasattr(self, "benefit_ledger_components")
+			)
+			if is_accrual_component:
+				self.append(
+					"accrued_benefits",
+					{
+						"salary_component": struct_row.salary_component,
+						"amount": amount,
+					},
+				)
+				self.benefit_ledger_components.append(
+					{
+						"salary_component": struct_row.salary_component,
+						"amount": amount,
+						"is_accrual": 1,
+						"transaction_type": "Accrual",
+						"flexible_benefit": 0,
+						"remarks": "Accrual Component assigned via salary structure",
+					}
+				)
 		else:
 			# default behavior, the system does not add if component amount is zero
 			# if remove_if_zero_valued is unchecked, then ask system to add component row
@@ -1189,7 +1343,9 @@ class SalarySlip(TransactionBase):
 				or (struct_row.amount_based_on_formula and amount is not None)
 				or (not remove_if_zero_valued and amount is not None and not self.data[struct_row.abbr])
 			):
-				default_amount = self.eval_condition_and_formula(struct_row, self.default_data)
+				# full-cycle default comes from SSA (period-independent); the slip only
+				# computes the prorated `amount` above (proration is a period concern)
+				default_amount = flt(struct_row.default_amount)
 				self.update_component_row(
 					struct_row,
 					amount,
@@ -1201,19 +1357,17 @@ class SalarySlip(TransactionBase):
 
 	def get_data_for_eval(self):
 		"""Returns data for evaluating formula"""
-		data = frappe._dict()
-		employee = frappe.get_cached_doc("Employee", self.employee).as_dict()
-
 		if not hasattr(self, "_salary_structure_assignment"):
 			self.set_salary_structure_assignment()
 
-		data.update(self._salary_structure_assignment)
+		data = get_component_eval_context(self.employee, self._salary_structure_assignment)
+		# Overlay salary-slip fields (payment_days, gross_pay, start_date, …) last, so the
+		# actual period context wins. Note: this means on a name collision a Salary Slip
+		# field takes precedence over an Employee field (employee is layered earlier in
+		# get_component_eval_context); no current formula relies on the reverse.
 		data.update(self.as_dict())
-		data.update(employee)
 
-		data.update(self.get_component_abbr_map())
-
-		# shallow copy of data to store default amounts (without payment days) for tax calculation
+		# shallow copy to store default amounts (without payment-days proration) for tax calculation
 		default_data = data.copy()
 
 		for key in ("earnings", "deductions"):
@@ -1223,24 +1377,14 @@ class SalarySlip(TransactionBase):
 
 		return data, default_data
 
-	def get_component_abbr_map(self):
-		def _fetch_component_values():
-			return {
-				component_abbr: 0
-				for component_abbr in frappe.get_all("Salary Component", pluck="salary_component_abbr")
-			}
-
-		return frappe.cache().get_value(SALARY_COMPONENT_VALUES, generator=_fetch_component_values)
-
 	def eval_condition_and_formula(self, struct_row, data):
 		try:
 			condition, formula, amount = struct_row.condition, struct_row.formula, struct_row.amount
 			if condition and not _safe_eval(condition, self.whitelisted_globals, data):
 				return None
 			if struct_row.amount_based_on_formula and formula:
-				amount = flt(
-					_safe_eval(formula, self.whitelisted_globals, data), struct_row.precision("amount")
-				)
+				# struct_row is a evaluated row (frappe._dict) from the SSA; precision is carried as an int
+				amount = flt(_safe_eval(formula, self.whitelisted_globals, data), struct_row.precision)
 			if amount:
 				data[struct_row.abbr] = amount
 
@@ -1270,48 +1414,215 @@ class SalarySlip(TransactionBase):
 			raise
 
 	def add_employee_benefits(self):
-		for struct_row in self._salary_structure_doc.get("earnings"):
-			if struct_row.is_flexible_benefit == 1:
-				if (
-					frappe.db.get_value(
-						"Salary Component",
-						struct_row.salary_component,
-						"pay_against_benefit_claim",
-						cache=True,
-					)
-					!= 1
-				):
-					benefit_component_amount = get_benefit_component_amount(
-						self.employee,
-						self.start_date,
-						self.end_date,
-						struct_row.salary_component,
-						self._salary_structure_doc,
-						self.payroll_frequency,
-						self.payroll_period,
-					)
-					if benefit_component_amount:
-						self.update_component_row(struct_row, benefit_component_amount, "earnings")
-				else:
-					benefit_claim_amount = get_benefit_claim_amount(
-						self.employee, self.start_date, self.end_date, struct_row.salary_component
-					)
-					if benefit_claim_amount:
-						self.update_component_row(struct_row, benefit_claim_amount, "earnings")
+		# Fetch employee benefits based on mandatory benefit application setting, get amounts for accrual or payouts for each and add to salary slip accrued_benefits/earnings table
+		if not self.payroll_period:
+			return
 
-		self.adjust_benefits_in_last_payroll_period(self.payroll_period)
+		self.benefit_details_parent, self.benefit_details_doctype = get_benefits_details_parent(
+			self.employee, self.payroll_period.name, self._salary_structure_assignment.name
+		)
 
-	def adjust_benefits_in_last_payroll_period(self, payroll_period):
-		if payroll_period:
-			if getdate(payroll_period.end_date) <= getdate(self.end_date):
-				last_benefits = get_last_payroll_period_benefits(
-					self.employee, self.start_date, self.end_date, payroll_period, self._salary_structure_doc
+		if not self.benefit_details_parent:
+			return
+
+		SalaryComponent = frappe.qb.DocType("Salary Component")
+		EmployeeBenefitDetail = frappe.qb.DocType(self.benefit_details_doctype)
+		employee_benefits = (
+			frappe.qb.from_(EmployeeBenefitDetail)
+			.join(SalaryComponent)
+			.on(EmployeeBenefitDetail.salary_component == SalaryComponent.name)
+			.select(
+				EmployeeBenefitDetail.salary_component,
+				EmployeeBenefitDetail.amount.as_("yearly_amount"),
+				SalaryComponent.payout_method,
+				SalaryComponent.depends_on_payment_days,
+				SalaryComponent.round_to_the_nearest_integer,
+				SalaryComponent.final_cycle_accrual_payout,
+			)
+			.where(EmployeeBenefitDetail.parent == self.benefit_details_parent)
+			.where(SalaryComponent.is_flexible_benefit == 1)
+			.where(SalaryComponent.accrual_component == 1)
+			.run(as_dict=True)
+		)
+
+		if employee_benefits:
+			employee_benefits = self.get_current_period_employee_benefit_amounts(employee_benefits)
+			self.add_current_period_employee_benefits(employee_benefits)
+
+	def add_current_period_employee_benefits(self, employee_benefits: dict):
+		"""Add flexible benefit payouts and accruals to salary slip Accrued Benefits table. Maintain benefit_ledger_components list to track accruals and payouts in this payroll cycle to be added to Employee Benefit Ledger."""
+		for benefit in employee_benefits:
+			if benefit.amount <= 0:
+				continue
+
+			earning_component = get_salary_component_data(benefit.salary_component)
+			if not earning_component.is_flexible_benefit:
+				continue
+
+			if benefit.is_accrual:
+				self.append(
+					"accrued_benefits",
+					{
+						"salary_component": benefit.salary_component,
+						"amount": benefit.amount,
+					},
 				)
-				if last_benefits:
-					for last_benefit in last_benefits:
-						last_benefit = frappe._dict(last_benefit)
-						amount = last_benefit.amount
-						self.update_component_row(frappe._dict(last_benefit.struct_row), amount, "earnings")
+			else:
+				self.update_component_row(
+					earning_component,
+					benefit.amount,
+					"earnings",
+				)
+
+			transaction_type = "Accrual" if benefit.is_accrual else "Payout"
+			remarks = "Pro rata flexible benefit accrual" if benefit.is_accrual else "Flexible benefit payout"
+
+			self.benefit_ledger_components.append(
+				{
+					"salary_component": benefit.salary_component,
+					"is_accrual": benefit.is_accrual,
+					"amount": flt(benefit.amount),
+					"transaction_type": transaction_type,
+					"flexible_benefit": 1,
+					"yearly_benefit": benefit.get("yearly_amount", 0),
+					"remarks": remarks,
+				}
+			)
+
+	def get_current_period_employee_benefit_amounts(self, employee_benefits: dict) -> dict:
+		"""Calculate employee benefit amounts for the current salary slip period based on payout method."""
+		from collections import defaultdict
+
+		is_last_payroll_cycle = False
+		if self.payroll_period and getdate(self.payroll_period.end_date) <= getdate(self.end_date):
+			is_last_payroll_cycle = True
+
+		total_sub_periods = get_period_factor(
+			self.employee,
+			self.start_date,
+			self.end_date,
+			self.payroll_frequency,
+			self.payroll_period,
+		)[0]
+
+		ledger_map = self._get_benefit_ledger_entries(employee_benefits)
+		precision = frappe.get_precision("Employee Benefit Detail", "amount")
+
+		# Process each benefit according to its payout method
+		for benefit in employee_benefits:
+			current_period_benefit = benefit.yearly_amount / total_sub_periods if total_sub_periods else 0
+			if benefit.depends_on_payment_days:
+				current_period_benefit = (
+					flt(current_period_benefit) * flt(self.payment_days) / cint(self.total_working_days)
+				)
+
+			# Get accrued and paid totals for this benefit
+			total_accrued = ledger_map[benefit.salary_component].get("Accrual", 0)
+			total_paid = ledger_map[benefit.salary_component].get("Payout", 0)
+
+			current_period_benefit, is_accrual = self._get_benefit_amount_and_transaction_type(
+				benefit, current_period_benefit, total_accrued, total_paid, is_last_payroll_cycle
+			)
+
+			current_period_benefit = flt(current_period_benefit, precision)
+			if benefit.round_to_the_nearest_integer:
+				current_period_benefit = rounded(current_period_benefit or 0)
+			benefit.is_accrual = is_accrual
+			benefit.amount = current_period_benefit
+
+		return employee_benefits
+
+	def _get_benefit_ledger_entries(self, employee_benefits):
+		"""Fetch existing benefit ledger entries and map amounts by benefit salary component and transaction type."""
+		from collections import defaultdict
+
+		ledger_entries = frappe.get_all(
+			"Employee Benefit Ledger",
+			filters={
+				"employee": self.employee,
+				"salary_component": ["in", [benefit.salary_component for benefit in employee_benefits]],
+				"payroll_period": self.payroll_period.name,
+			},
+			fields=["salary_component", "transaction_type", "amount"],
+		)
+		benefit_ledger_map = defaultdict(lambda: defaultdict(float))
+		for entry in ledger_entries:
+			benefit_ledger_map[entry["salary_component"]][entry["transaction_type"]] += entry["amount"]
+
+		return benefit_ledger_map
+
+	def _get_benefit_amount_and_transaction_type(
+		self, benefit, current_period_benefit, total_accrued, total_paid, is_last_payroll_cycle
+	):  # Process according to payout method
+		is_accrual = 1
+
+		if benefit.payout_method == "Accrue and payout at end of payroll period":
+			current_period_benefit, is_accrual = self._get_final_period_benefit_payout(
+				benefit, current_period_benefit, total_accrued, total_paid, is_last_payroll_cycle
+			)
+		elif benefit.payout_method == "Accrue per cycle, pay only on claim":
+			current_period_benefit, is_accrual = self._get_claim_based_benefit_payout(
+				benefit, current_period_benefit, total_accrued, total_paid, is_last_payroll_cycle
+			)
+
+		return current_period_benefit, is_accrual
+
+	def _get_final_period_benefit_payout(
+		self, benefit, current_period_benefit, total_accrued, total_paid, is_last_payroll_cycle
+	):
+		"""Process 'Accrue and payout at end of payroll period' benefit"""
+		is_accrual = 1
+		benefit_claims = [
+			row
+			for row in self.earnings
+			if row.salary_component == benefit.salary_component and getattr(row, "additional_salary", None)
+		]  # Any claims for this benefit component to be paid via additional salary in this payroll cycle
+		claimed_amount = sum(row.amount for row in benefit_claims) if benefit_claims else 0
+		total_paid += claimed_amount
+
+		if 0 < (benefit.yearly_amount - total_accrued) < current_period_benefit:
+			current_period_benefit = (
+				benefit.yearly_amount - total_accrued
+			)  # Limit benefit amount to remaining yearly amount
+
+		if is_last_payroll_cycle:  # On last payroll cycle, pay out all accrued benefits
+			current_period_benefit = max(total_accrued + current_period_benefit - total_paid, 0)
+			is_accrual = 0
+
+		return current_period_benefit, is_accrual
+
+	def _get_claim_based_benefit_payout(
+		self, benefit, current_period_benefit, total_accrued, total_paid, is_last_payroll_cycle
+	):
+		"""Process 'Accrue per cycle, pay only on claim' benefits.
+		Always record the full entitlement for the current cycle, even if part of it
+		was already claimed. This ensures the Employee Benefit Ledger shows
+		the correct total entitlement for accurate future claim balance calculations.
+		"""
+		is_accrual = 1
+		benefit_claims = [
+			row
+			for row in self.earnings
+			if row.salary_component == benefit.salary_component and getattr(row, "additional_salary", None)
+		]
+		claimed_amount = sum(row.amount for row in benefit_claims) if benefit_claims else 0
+		total_paid += claimed_amount
+
+		# if more was paid than accrued, reduce current period accrual accordingly
+		if total_paid > total_accrued:
+			current_period_benefit -= total_paid - total_accrued
+
+		if 0 < (benefit.yearly_amount - total_accrued) < current_period_benefit:
+			current_period_benefit = (
+				benefit.yearly_amount - total_accrued
+			)  # Limit benefit amount to remaining yearly amount
+
+		# Pay out all unclaimed benefits in final cycle if final payout option is enabled
+		if is_last_payroll_cycle and benefit.final_cycle_accrual_payout:
+			current_period_benefit = max(total_accrued + current_period_benefit - total_paid, 0)
+			is_accrual = 0
+
+		return current_period_benefit, is_accrual
 
 	def add_additional_salary_components(self, component_type):
 		additional_salaries = get_additional_salaries(
@@ -1319,25 +1630,52 @@ class SalarySlip(TransactionBase):
 		)
 
 		for additional_salary in additional_salaries:
+			component_data = get_salary_component_data(additional_salary.component)
+			remove_if_zero_valued = frappe.get_cached_value(
+				"Salary Component", additional_salary.component, "remove_if_zero_valued"
+			)
+			if flt(additional_salary.amount) == 0 and remove_if_zero_valued:
+				continue
 			self.update_component_row(
-				get_salary_component_data(additional_salary.component),
+				component_data,
 				additional_salary.amount,
 				component_type,
 				additional_salary,
 				is_recurring=additional_salary.is_recurring,
 			)
 
+			if component_type == "earnings" and hasattr(self, "benefit_ledger_components"):
+				if (
+					additional_salary.ref_doctype == "Employee Benefit Claim"
+					and component_data.is_flexible_benefit
+				) or component_data.accrual_component:
+					# track benefit claim or accrual component payout to record in Employee Benefit Ledger
+					if additional_salary.ref_doctype == "Employee Benefit Claim":
+						remarks = f"Payout against Employee Benefit Claim {additional_salary.ref_docname}"
+						flexible_benefit = 1
+					else:
+						remarks = "Accrual Component payout via Additional Salary"
+						flexible_benefit = 0
+
+					self.benefit_ledger_components.append(
+						{
+							"salary_component": additional_salary.component,
+							"amount": additional_salary.amount,
+							"is_accrual": 0,
+							"transaction_type": "Payout",
+							"flexible_benefit": flexible_benefit,
+							"remarks": remarks,
+						}
+					)
+
 	def add_tax_components(self):
 		# Calculate variable_based_on_taxable_salary after all components updated in salary slip
 		tax_components, self.other_deduction_components = [], []
-		for d in self._salary_structure_doc.get("deductions"):
+		for d in self._evaluated_components["deductions"]:
 			if d.variable_based_on_taxable_salary == 1 and not d.formula and not flt(d.amount):
 				tax_components.append(d.salary_component)
 			else:
 				self.other_deduction_components.append(d.salary_component)
-
-		if self.handle_additional_salary_tax_component():
-			return
 
 		# consider manually added tax component
 		if not tax_components:
@@ -1409,6 +1747,7 @@ class SalarySlip(TransactionBase):
 				sca.company,
 			)
 			.where(sc.variable_based_on_taxable_salary == 1)
+			.where(sc.disabled == 0)
 		).run(as_dict=True)
 
 		for component in components:
@@ -1489,6 +1828,7 @@ class SalarySlip(TransactionBase):
 				"abbr",
 				"do_not_include_in_total",
 				"do_not_include_in_accounts",
+				"accrual_component",
 				"is_tax_applicable",
 				"is_flexible_benefit",
 				"variable_based_on_taxable_salary",
@@ -1520,7 +1860,17 @@ class SalarySlip(TransactionBase):
 
 		component_row.amount = amount
 
-		self.update_component_amount_based_on_payment_days(component_row, remove_if_zero_valued)
+		# Skip payment days adjustment for:
+		# 1. Arrear/Payroll Correction additional salary - already calculated based on LWP days in previous cycles
+		# 2. Employee Benefit Claim - payout often includes amount for previous cycles
+		# 2. Accrual components - paid based on accrual amounts from previous cycles
+		skip_payment_days_adjustment = (
+			additional_salary
+			and additional_salary.get("ref_doctype")
+			in ["Arrear", "Payroll Correction", "Employee Benefit Claim"]
+		) or component_row.accrual_component
+		if not skip_payment_days_adjustment:
+			self.update_component_amount_based_on_payment_days(component_row, remove_if_zero_valued)
 
 		if data:
 			data[component_row.abbr] = component_row.amount
@@ -1564,10 +1914,12 @@ class SalarySlip(TransactionBase):
 
 		if has_additional_salary_tax_component:
 			self.current_structured_tax_amount = self.additional_salary_amount
-		else:
+		elif self.remaining_sub_periods > 0:
 			self.current_structured_tax_amount = (
 				self.total_structured_tax_amount - self.previous_total_paid_taxes
 			) / self.remaining_sub_periods
+		else:
+			self.current_structured_tax_amount = 0.0
 
 		# Total taxable earnings with additional earnings with full tax
 		self.full_tax_on_additional_earnings = 0.0
@@ -1655,10 +2007,7 @@ class SalarySlip(TransactionBase):
 		ss = frappe.qb.DocType("Salary Slip")
 		sd = frappe.qb.DocType("Salary Detail")
 
-		if field_to_select == "amount":
-			field = sd.amount
-		else:
-			field = sd.additional_amount
+		field = sd.amount if field_to_select == "amount" else sd.additional_amount
 
 		query = (
 			frappe.qb.from_(ss)
@@ -1686,7 +2035,6 @@ class SalarySlip(TransactionBase):
 			query = query.where(sd.salary_component == salary_component)
 
 		result = query.run()
-
 		return flt(result[0][0]) if result else 0.0
 
 	def get_tax_paid_in_period(self, start_date, end_date, tax_component):
@@ -1707,7 +2055,6 @@ class SalarySlip(TransactionBase):
 		taxable_earnings = 0
 		additional_income = 0
 		additional_income_with_full_tax = 0
-		flexi_benefits = 0
 		amount_exempted_from_income_tax = 0
 
 		for earning in self.earnings:
@@ -1715,25 +2062,22 @@ class SalarySlip(TransactionBase):
 				amount, additional_amount = self.get_amount_based_on_payment_days(earning)
 			else:
 				if earning.additional_amount:
-					amount, additional_amount = earning.amount, earning.additional_amount
+					amount, additional_amount = earning.amount or 0, earning.additional_amount or 0
 				else:
-					amount, additional_amount = earning.default_amount, earning.additional_amount
+					amount, additional_amount = earning.default_amount or 0, earning.additional_amount or 0
 
 			if earning.is_tax_applicable:
-				if earning.is_flexible_benefit:
-					flexi_benefits += amount
-				else:
-					taxable_earnings += amount - additional_amount
-					additional_income += additional_amount
+				taxable_earnings += amount - additional_amount
+				additional_income += additional_amount
 
-					# Get additional amount based on future recurring additional salary
-					if additional_amount and earning.is_recurring_additional_salary:
-						additional_income += self.get_future_recurring_additional_amount(
-							earning.additional_salary, earning.additional_amount
-						)  # Used earning.additional_amount to consider the amount for the full month
+				# Get additional amount based on future recurring additional salary
+				if additional_amount and earning.is_recurring_additional_salary:
+					additional_income += self.get_future_recurring_additional_amount(
+						earning.additional_salary, earning.additional_amount
+					)  # Used earning.additional_amount to consider the amount for the full month
 
-					if earning.deduct_full_tax_on_selected_payroll_date:
-						additional_income_with_full_tax += additional_amount
+				if earning.deduct_full_tax_on_selected_payroll_date:
+					additional_income_with_full_tax += additional_amount
 
 		if allow_tax_exemption:
 			for ded in self.deductions:
@@ -1757,7 +2101,6 @@ class SalarySlip(TransactionBase):
 				"additional_income": additional_income,
 				"amount_exempted_from_income_tax": amount_exempted_from_income_tax,
 				"additional_income_with_full_tax": additional_income_with_full_tax,
-				"flexi_benefits": flexi_benefits,
 			}
 		)
 
@@ -1801,7 +2144,7 @@ class SalarySlip(TransactionBase):
 
 	def get_amount_based_on_payment_days(self, row):
 		amount, additional_amount = row.amount, row.additional_amount
-		timesheet_component = self._salary_structure_doc.salary_component
+		timesheet_component = getattr(self, "_timesheet_component", None)
 
 		if not row.additional_salary and not row.default_amount:
 			amount, additional_amount = amount, additional_amount
@@ -1836,8 +2179,8 @@ class SalarySlip(TransactionBase):
 			and cint(row.depends_on_payment_days)
 		):
 			amount, additional_amount = 0, 0
-		elif not row.amount:
-			amount = flt(row.default_amount) + flt(row.additional_amount)
+		elif not row.amount and row.additional_amount:
+			amount = flt(row.additional_amount)
 
 		# apply rounding
 		if frappe.db.get_value(
@@ -1846,34 +2189,6 @@ class SalarySlip(TransactionBase):
 			amount, additional_amount = rounded(amount or 0), rounded(additional_amount or 0)
 
 		return amount, additional_amount
-
-	def calculate_unclaimed_taxable_benefits(self):
-		# get total sum of benefits paid
-		total_benefits_paid = self.get_salary_slip_details(
-			self.payroll_period.start_date,
-			self.start_date,
-			parentfield="earnings",
-			is_tax_applicable=1,
-			is_flexible_benefit=1,
-		)
-
-		# get total benefits claimed
-		BenefitClaim = frappe.qb.DocType("Employee Benefit Claim")
-		total_benefits_claimed = (
-			frappe.qb.from_(BenefitClaim)
-			.select(Sum(BenefitClaim.claimed_amount))
-			.where(
-				(BenefitClaim.docstatus == 1)
-				& (BenefitClaim.employee == self.employee)
-				& (BenefitClaim.claim_date.between(self.payroll_period.start_date, self.end_date))
-			)
-		).run()
-		total_benefits_claimed = flt(total_benefits_claimed[0][0]) if total_benefits_claimed else 0
-
-		unclaimed_taxable_benefits = (
-			total_benefits_paid - total_benefits_claimed
-		) + self.current_taxable_earnings_for_payment_days.flexi_benefits
-		return unclaimed_taxable_benefits
 
 	def get_total_exemption_amount(self):
 		total_exemption_amount = 0
@@ -1912,20 +2227,26 @@ class SalarySlip(TransactionBase):
 					"company": self.company,
 					"docstatus": 1,
 				},
-				fields="SUM(amount) as total_amount",
+				fields=[{"SUM": "amount", "as": "total_amount"}],
 			)[0].total_amount
 			or 0.0
 		)
 
 	def get_component_totals(self, component_type, depends_on_payment_days=0):
 		total = 0.0
-		for d in self.get(component_type):
-			if not d.do_not_include_in_total:
-				if depends_on_payment_days:
-					amount = self.get_amount_based_on_payment_days(d)[0]
-				else:
-					amount = flt(d.amount, d.precision("amount"))
-				total += amount
+		components = self.get(component_type) or []
+
+		for d in components:
+			if d.do_not_include_in_total:
+				continue
+
+			if depends_on_payment_days:
+				amount = self.get_amount_based_on_payment_days(d)[0]
+			else:
+				amount = flt(d.amount, d.precision("amount"))
+
+			total += amount
+
 		return total
 
 	def email_salary_slip(self):
@@ -1949,6 +2270,7 @@ class SalarySlip(TransactionBase):
 				).format(payroll_settings.password_policy)
 
 		if receiver:
+			posting_date = getdate(self.posting_date)
 			email_args = {
 				"sender": payroll_settings.sender_email,
 				"recipients": [receiver],
@@ -1959,6 +2281,7 @@ class SalarySlip(TransactionBase):
 				],
 				"reference_doctype": self.doctype,
 				"reference_name": self.name,
+				"send_after": posting_date if posting_date > getdate() else None,
 			}
 			if not frappe.flags.in_test:
 				enqueue(method=frappe.sendmail, queue="short", timeout=300, is_async=True, **email_args)
@@ -1982,12 +2305,12 @@ class SalarySlip(TransactionBase):
 			status = self.get_status()
 		self.db_set("status", status)
 
-	def process_salary_structure(self, for_preview=0):
+	def process_salary_structure(self, for_preview=0, lwp_days_corrected=None):
 		"""Calculate salary after salary structure details have been updated"""
 		if self.payroll_frequency:
 			self.get_date_details()
 		self.pull_emp_details()
-		self.get_working_days_details(for_preview=for_preview)
+		self.get_working_days_details(for_preview=for_preview, lwp_days_corrected=lwp_days_corrected)
 		self.calculate_net_pay()
 
 	def pull_emp_details(self):
@@ -2000,12 +2323,12 @@ class SalarySlip(TransactionBase):
 			self.bank_account_no = account_details.bank_ac_no
 
 	@frappe.whitelist()
-	def process_salary_based_on_working_days(self):
+	def process_salary_based_on_working_days(self) -> None:
 		self.get_working_days_details(lwp=self.leave_without_pay)
 		self.calculate_net_pay()
 
 	@frappe.whitelist()
-	def set_totals(self):
+	def set_totals(self) -> None:
 		self.gross_pay = 0.0
 		if self.salary_slip_based_on_timesheet == 1:
 			self.calculate_total_for_salary_slip_based_on_timesheet()
@@ -2056,7 +2379,7 @@ class SalarySlip(TransactionBase):
 
 		salary_slip_sum = frappe.get_list(
 			"Salary Slip",
-			fields=["sum(net_pay) as net_sum", "sum(gross_pay) as gross_sum"],
+			fields=[{"SUM": "net_pay", "as": "net_sum"}, {"SUM": "gross_pay", "as": "gross_sum"}],
 			filters={
 				"employee": self.employee,
 				"start_date": [">=", period_start_date],
@@ -2079,7 +2402,7 @@ class SalarySlip(TransactionBase):
 		first_day_of_the_month = get_first_day(self.start_date)
 		salary_slip_sum = frappe.get_list(
 			"Salary Slip",
-			fields=["sum(net_pay) as sum"],
+			fields=[{"SUM": "net_pay", "as": "sum"}],
 			filters={
 				"employee": self.employee,
 				"start_date": [">=", first_day_of_the_month],
@@ -2155,6 +2478,43 @@ class SalarySlip(TransactionBase):
 					},
 				)
 
+	def on_discard(self):
+		self.db_set("status", "Cancelled")
+
+
+def get_benefits_details_parent(employee, payroll_period, salary_structure_assignment):
+	"""Returns the parent and doctype of benefit details based on the following logic:
+	1. If 'Mandatory Benefit Application' is enabled in Payroll Settings, only consider Employee Benefit Application
+	2. If not enabled, prefer Employee Benefit Application but fallback to Salary Structure Assignment if
+	   former does not exist"""
+	mandatory_benefit_application = frappe.db.get_single_value(
+		"Payroll Settings", "mandatory_benefit_application"
+	)
+	benefit_details_parent = None
+	benefit_details_doctype = None
+	# Check if Employee Benefit Application exists
+	employee_benefit_application = frappe.db.get_value(
+		"Employee Benefit Application",
+		{"employee": employee, "payroll_period": payroll_period, "docstatus": 1},
+		"name",
+	)
+
+	if mandatory_benefit_application:
+		# If mandatory, only consider Employee Benefit Application
+		if employee_benefit_application:
+			benefit_details_parent = employee_benefit_application
+			benefit_details_doctype = "Employee Benefit Application Detail"
+	else:
+		# If not mandatory, prefer Employee Benefit Application but fallback to Salary Structure Assignment
+		if employee_benefit_application:
+			benefit_details_parent = employee_benefit_application
+			benefit_details_doctype = "Employee Benefit Application Detail"
+		else:
+			benefit_details_parent = salary_structure_assignment
+			benefit_details_doctype = "Employee Benefit Detail"
+
+	return benefit_details_parent, benefit_details_doctype
+
 
 def unlink_ref_doc_from_salary_slip(doc, method=None):
 	"""Unlinks accrual Journal Entry from Salary Slips on cancellation"""
@@ -2183,9 +2543,12 @@ def get_salary_component_data(component):
 			"depends_on_payment_days",
 			"salary_component_abbr as abbr",
 			"do_not_include_in_total",
+			"do_not_include_in_accounts",
 			"is_tax_applicable",
 			"is_flexible_benefit",
 			"variable_based_on_taxable_salary",
+			"accrual_component",
+			"exempted_from_income_tax",
 		),
 		as_dict=1,
 		cache=True,
@@ -2203,76 +2566,6 @@ def get_payroll_payable_account(company, payroll_entry):
 		)
 
 	return payroll_payable_account
-
-
-def calculate_tax_by_tax_slab(annual_taxable_earning, tax_slab, eval_globals=None, eval_locals=None):
-	from hrms.hr.utils import calculate_tax_with_marginal_relief
-
-	tax_amount = 0
-	total_other_taxes_and_charges = 0
-
-	if annual_taxable_earning > tax_slab.tax_relief_limit:
-		eval_locals.update({"annual_taxable_earning": annual_taxable_earning})
-
-		for slab in tax_slab.slabs:
-			cond = cstr(slab.condition).strip()
-			if cond and not eval_tax_slab_condition(cond, eval_globals, eval_locals):
-				continue
-			if not slab.to_amount and annual_taxable_earning >= slab.from_amount:
-				tax_amount += (annual_taxable_earning - slab.from_amount + 1) * slab.percent_deduction * 0.01
-				continue
-
-			if annual_taxable_earning >= slab.from_amount and annual_taxable_earning < slab.to_amount:
-				tax_amount += (annual_taxable_earning - slab.from_amount + 1) * slab.percent_deduction * 0.01
-			elif annual_taxable_earning >= slab.from_amount and annual_taxable_earning >= slab.to_amount:
-				tax_amount += (slab.to_amount - slab.from_amount + 1) * slab.percent_deduction * 0.01
-
-		tax_with_marginal_relief = calculate_tax_with_marginal_relief(
-			tax_slab, tax_amount, annual_taxable_earning
-		)
-		if tax_with_marginal_relief is not None:
-			tax_amount = tax_with_marginal_relief
-
-		for d in tax_slab.other_taxes_and_charges:
-			if flt(d.min_taxable_income) and flt(d.min_taxable_income) > annual_taxable_earning:
-				continue
-
-			if flt(d.max_taxable_income) and flt(d.max_taxable_income) < annual_taxable_earning:
-				continue
-			other_taxes_and_charges = tax_amount * flt(d.percent) / 100
-			tax_amount += other_taxes_and_charges
-			total_other_taxes_and_charges += other_taxes_and_charges
-
-	return tax_amount, total_other_taxes_and_charges
-
-
-def eval_tax_slab_condition(condition, eval_globals=None, eval_locals=None):
-	if not eval_globals:
-		eval_globals = {
-			"int": int,
-			"float": float,
-			"long": int,
-			"round": round,
-			"date": date,
-			"getdate": getdate,
-			"get_first_day": get_first_day,
-			"get_last_day": get_last_day,
-		}
-
-	try:
-		condition = condition.strip()
-		if condition:
-			return frappe.safe_eval(condition, eval_globals, eval_locals)
-	except NameError as err:
-		frappe.throw(
-			_("{0} <br> This error can be due to missing or deleted field.").format(err),
-			title=_("Name error"),
-		)
-	except SyntaxError as err:
-		frappe.throw(_("Syntax error in condition: {0} in Income Tax Slab").format(err))
-	except Exception as e:
-		frappe.throw(_("Error in formula or condition: {0} in Income Tax Slab").format(e))
-		raise
 
 
 def get_lwp_or_ppl_for_date_range(employee, start_date, end_date):
@@ -2317,7 +2610,8 @@ def get_lwp_or_ppl_for_date_range(employee, start_date, end_date):
 
 
 @frappe.whitelist()
-def make_salary_slip_from_timesheet(source_name, target_doc=None):
+def make_salary_slip_from_timesheet(source_name: str, target_doc: str | Document | None = None) -> Document:
+	frappe.has_permission("Timesheet", "read", source_name, throw=True)
 	target = frappe.new_doc("Salary Slip")
 	set_missing_values(source_name, target)
 	target.run_method("get_emp_and_working_day_details")
@@ -2337,81 +2631,51 @@ def set_missing_values(time_sheet, target):
 	target.append("timesheets", {"time_sheet": doc.name, "working_hours": doc.total_hours})
 
 
-def throw_error_message(row, error, title, description=None):
-	data = frappe._dict(
-		{
-			"doctype": row.parenttype,
-			"name": row.parent,
-			"doclink": get_link_to_form(row.parenttype, row.parent),
-			"row_id": row.idx,
-			"error": error,
-			"title": title,
-			"description": description or "",
-		}
-	)
+def verify_lwp_days_corrected(employee, start_date, end_date, lwp_days_corrected):
+	#  Verify that the provided lwp_days_corrected matches actual payroll corrections.
+	PayrollCorrection = frappe.qb.DocType("Payroll Correction")
+	SalarySlip = frappe.qb.DocType("Salary Slip")
 
-	message = _(
-		"Error while evaluating the {doctype} {doclink} at row {row_id}. <br><br> <b>Error:</b> {error} <br><br> <b>Hint:</b> {description}"
-	).format(**data)
+	actual_days_reversed = (
+		frappe.qb.from_(PayrollCorrection)
+		.join(SalarySlip)
+		.on(PayrollCorrection.salary_slip_reference == SalarySlip.name)
+		.select(Sum(PayrollCorrection.days_to_reverse).as_("total_days"))
+		.where(
+			(PayrollCorrection.employee == employee)
+			& (PayrollCorrection.docstatus == 1)
+			& (SalarySlip.start_date == start_date)
+			& (SalarySlip.end_date == end_date)
+		)
+	).run(pluck=True)
 
-	frappe.throw(message, title=title)
+	actual_total = actual_days_reversed[0] or 0.0
+
+	if lwp_days_corrected != actual_total:
+		frappe.throw(
+			_(
+				"LWP Days Reversed ({0}) does not match actual Payroll Corrections total ({1}) for employee {2} from {3} to {4}"
+			).format(lwp_days_corrected, actual_total, employee, start_date, end_date),
+			title=_("Invalid LWP Days Reversed"),
+		)
+
+	return True
 
 
 def on_doctype_update():
 	frappe.db.add_index("Salary Slip", ["employee", "start_date", "end_date"])
 
 
-def _safe_eval(code: str, eval_globals: dict | None = None, eval_locals: dict | None = None):
-	"""Old version of safe_eval from framework.
-
-	Note: current frappe.safe_eval transforms code so if you have nested
-	iterations with too much depth then it can hit recursion limit of python.
-	There's no workaround for this and people need large formulas in some
-	countries so this is alternate implementation for that.
-
-	WARNING: DO NOT use this function anywhere else outside of this file.
-	"""
-	code = unicodedata.normalize("NFKC", code)
-
-	_check_attributes(code)
-
-	whitelisted_globals = {"int": int, "float": float, "long": int, "round": round}
-	if not eval_globals:
-		eval_globals = {}
-
-	eval_globals["__builtins__"] = {}
-	eval_globals.update(whitelisted_globals)
-	return eval(code, eval_globals, eval_locals)  # nosemgrep
-
-
-def _check_attributes(code: str) -> None:
-	import ast
-
-	from frappe.utils.safe_exec import UNSAFE_ATTRIBUTES
-
-	unsafe_attrs = set(UNSAFE_ATTRIBUTES).union(["__"]) - {"format"}
-
-	for attribute in unsafe_attrs:
-		if attribute in code:
-			raise SyntaxError(f'Illegal rule {frappe.bold(code)}. Cannot use "{attribute}"')
-
-	BLOCKED_NODES = (ast.NamedExpr,)
-
-	tree = ast.parse(code, mode="eval")
-	for node in ast.walk(tree):
-		if isinstance(node, BLOCKED_NODES):
-			raise SyntaxError(f"Operation not allowed: line {node.lineno} column {node.col_offset}")
-		if isinstance(node, ast.Attribute) and isinstance(node.attr, str) and node.attr in UNSAFE_ATTRIBUTES:
-			raise SyntaxError(f'Illegal rule {frappe.bold(code)}. Cannot use "{node.attr}"')
-
-
 @frappe.whitelist()
-def enqueue_email_salary_slips(names) -> None:
+def enqueue_email_salary_slips(names: list | str) -> None:
 	"""enqueue bulk emailing salary slips"""
 	import json
 
 	if isinstance(names, str):
 		names = json.loads(names)
+
+	for name in names:
+		frappe.has_permission("Salary Slip", "read", name, throw=True)
 
 	frappe.enqueue("hrms.payroll.doctype.salary_slip.salary_slip.email_salary_slips", names=names)
 	frappe.msgprint(

--- a/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
@@ -31,11 +31,6 @@ def set_loan_repayment(doc: "SalarySlip"):
 
 	if not doc.get("loans", []):
 		loan_details = _get_loan_details(doc)
-		if loan_details:
-			process_loan_interest_accruals(loan_details, doc.end_date)
-
-		for loan in loan_details:
-			amounts = calculate_amounts(loan.name, doc.end_date, "Regular Payment")
 
 		for loan in loan_details:
 			amounts = calculate_amounts(loan.name, doc.end_date)
@@ -56,8 +51,9 @@ def set_loan_repayment(doc: "SalarySlip"):
 		doc.set("loans", [])
 
 	for payment in doc.get("loans", []):
-		amounts = calculate_amounts(payment.loan, doc.end_date, "Regular Payment")
-		total_amount = amounts["interest_amount"] + amounts["payable_principal_amount"]
+		amounts = calculate_amounts(payment.loan, doc.end_date)
+		total_amount = amounts["payable_amount"]
+
 		if payment.total_payment > total_amount:
 			frappe.throw(
 				_(
@@ -75,17 +71,10 @@ def set_loan_repayment(doc: "SalarySlip"):
 		doc.total_loan_repayment += payment.total_payment
 
 
-def _get_loan_details(doc: "SalarySlip") -> dict[str, str | bool]:
+def _get_loan_details(doc: "SalarySlip") -> dict[str, Any]:
 	loan_details = frappe.get_all(
 		"Loan",
-		fields=[
-			"name",
-			"interest_income_account",
-			"loan_account",
-			"loan_product",
-			"is_term_loan",
-			"cost_center",
-		],
+		fields=["name", "interest_income_account", "loan_account", "loan_product", "is_term_loan"],
 		filters={
 			"applicant": doc.employee,
 			"docstatus": 1,
@@ -95,18 +84,6 @@ def _get_loan_details(doc: "SalarySlip") -> dict[str, str | bool]:
 		},
 	)
 	return loan_details
-
-
-def process_loan_interest_accruals(loan_details: dict[str, str | bool], posting_date: str):
-	from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual import (
-		process_loan_interest_accrual_for_term_loans,
-	)
-
-	for loan in loan_details:
-		if loan.is_term_loan:
-			process_loan_interest_accrual_for_term_loans(
-				posting_date=posting_date, loan_product=loan.loan_product, loan=loan.name
-			)
 
 
 @if_lending_app_installed
@@ -144,7 +121,6 @@ def make_loan_repayment_entry(doc: "SalarySlip"):
 	from lending.loan_management.doctype.loan_repayment.loan_repayment import create_repayment_entry
 
 	payroll_payable_account = get_payroll_payable_account(doc.company, doc.payroll_entry)
-	cost_center_account = get_cost_center_account(doc.company, doc.payroll_entry)
 	process_payroll_accounting_entry_based_on_employee = frappe.db.get_single_value(
 		"Payroll Settings", "process_payroll_accounting_entry_based_on_employee"
 	)
@@ -168,13 +144,16 @@ def make_loan_repayment_entry(doc: "SalarySlip"):
 			loan.total_payment,
 			payroll_payable_account=payroll_payable_account,
 			process_payroll_accounting_entry_based_on_employee=process_payroll_accounting_entry_based_on_employee,
+			value_date=doc.end_date,
 		)
 
-		loan_cost_center = frappe.db.get_value("Loan", loan.loan, "cost_center")
-		repayment_entry.cost_center = loan_cost_center or cost_center_account
-
 		repayment_entry.save()
+
+		if not process_payroll_accounting_entry_based_on_employee:
+			frappe.flags.party_not_required = True
+
 		repayment_entry.submit()
+		frappe.flags.party_not_required = False
 
 		frappe.db.set_value("Salary Slip Loan", loan.name, "loan_repayment_entry", repayment_entry.name)
 
@@ -199,12 +178,3 @@ def get_payroll_payable_account(company, payroll_entry):
 		payroll_payable_account = frappe.db.get_value("Company", company, "default_payroll_payable_account")
 
 	return payroll_payable_account
-
-
-def get_cost_center_account(company, payroll_entry):
-	if payroll_entry:
-		cost_center_account = frappe.db.get_value("Payroll Entry", payroll_entry, "cost_center")
-	else:
-		cost_center_account = frappe.db.get_value("Company", company, "cost_center")
-
-	return cost_center_account

--- a/hrms/payroll/doctype/salary_structure/salary_structure.json
+++ b/hrms/payroll/doctype/salary_structure/salary_structure.json
@@ -24,8 +24,11 @@
   "salary_component",
   "hour_rate",
   "earning_deduction",
+  "column_break_besp",
   "earnings",
   "deductions",
+  "employer_contributions",
+  "employee_benefits",
   "conditions_and_formula_variable_and_example",
   "net_pay_detail",
   "total_earning",
@@ -161,6 +164,12 @@
    "options": "Salary Detail"
   },
   {
+   "fieldname": "employer_contributions",
+   "fieldtype": "Table",
+   "label": "Employer Contributions",
+   "options": "Salary Detail"
+  },
+  {
    "fieldname": "net_pay_detail",
    "fieldtype": "Section Break",
    "options": "Simple"
@@ -236,13 +245,24 @@
    "options": "Currency",
    "reqd": 1,
    "search_index": 1
+  },
+  {
+   "description": "Enter yearly benefit amounts",
+   "fieldname": "employee_benefits",
+   "fieldtype": "Table",
+   "label": "Flexible Benefits",
+   "options": "Employee Benefit Detail"
+  },
+  {
+   "fieldname": "column_break_besp",
+   "fieldtype": "Column Break"
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-11-22 11:17:28.384386",
+ "modified": "2026-06-08 17:39:39.847210",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Structure",
@@ -280,6 +300,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "show_name_in_global_search": 1,
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/hrms/payroll/doctype/salary_structure/salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/salary_structure.py
@@ -1,13 +1,14 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
+import datetime
 import re
 
 import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
-from frappe.utils import cint, cstr, flt
+from frappe.utils import cint, cstr, flt, get_link_to_form
 
 import erpnext
 
@@ -15,6 +16,39 @@ from hrms.payroll.utils import sanitize_expression
 
 
 class SalaryStructure(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from hrms.payroll.doctype.employee_benefit_detail.employee_benefit_detail import EmployeeBenefitDetail
+		from hrms.payroll.doctype.salary_detail.salary_detail import SalaryDetail
+
+		amended_from: DF.Link | None
+		company: DF.Link
+		currency: DF.Link
+		deductions: DF.Table[SalaryDetail]
+		earnings: DF.Table[SalaryDetail]
+		employee_benefits: DF.Table[EmployeeBenefitDetail]
+		hour_rate: DF.Currency
+		is_active: DF.Literal["", "Yes", "No"]
+		is_default: DF.Literal["Yes", "No"]
+		leave_encashment_amount_per_day: DF.Currency
+		letter_head: DF.Link | None
+		max_benefits: DF.Currency
+		mode_of_payment: DF.Link | None
+		net_pay: DF.Currency
+		payment_account: DF.Link | None
+		payroll_frequency: DF.Literal["", "Monthly", "Fortnightly", "Bimonthly", "Weekly", "Daily"]
+		salary_component: DF.Link | None
+		salary_slip_based_on_timesheet: DF.Check
+		total_deduction: DF.Currency
+		total_earning: DF.Currency
+	# end: auto-generated types
+
 	def before_validate(self):
 		self.sanitize_condition_and_formula_fields()
 
@@ -24,11 +58,11 @@ class SalaryStructure(Document):
 	def validate(self):
 		self.set_missing_values()
 		self.validate_amount()
-		self.validate_max_benefits_with_flexi()
 		self.validate_component_based_on_tax_slab()
 		self.validate_payment_days_based_dependent_component()
 		self.validate_timesheet_component()
 		self.validate_formula_setup()
+		validate_max_benefit_for_flexible_benefit(self.employee_benefits, self.max_benefits)
 
 	def on_update(self):
 		self.reset_condition_and_formula_fields()
@@ -135,7 +169,7 @@ class SalaryStructure(Document):
 				break
 
 	def sanitize_condition_and_formula_fields(self):
-		for table in ("earnings", "deductions"):
+		for table in ("earnings", "deductions", "employer_contributions"):
 			for row in self.get(table):
 				row.condition = row.condition.strip() if row.condition else ""
 				row.formula = row.formula.strip() if row.formula else ""
@@ -144,69 +178,38 @@ class SalaryStructure(Document):
 
 	def reset_condition_and_formula_fields(self):
 		# set old values (allowing multiline strings for better readability in the doctype form)
-		for table in ("earnings", "deductions"):
+		for table in ("earnings", "deductions", "employer_contributions"):
 			for row in self.get(table):
 				row.condition = row._condition
 				row.formula = row._formula
 
 		self.db_update_all()
 
-	def validate_max_benefits_with_flexi(self):
-		have_a_flexi = False
-		if self.earnings:
-			flexi_amount = 0
-			for earning_component in self.earnings:
-				if earning_component.is_flexible_benefit == 1:
-					have_a_flexi = True
-					max_of_component = frappe.db.get_value(
-						"Salary Component", earning_component.salary_component, "max_benefit_amount"
-					)
-					flexi_amount += max_of_component
-
-			if have_a_flexi and flt(self.max_benefits) == 0:
-				frappe.throw(_("Max benefits should be greater than zero to dispense benefits"))
-			if have_a_flexi and flexi_amount and flt(self.max_benefits) > flexi_amount:
-				frappe.throw(
-					_(
-						"Total flexible benefit component amount {0} should not be less than max benefits {1}"
-					).format(flexi_amount, self.max_benefits)
-				)
-		if not have_a_flexi and flt(self.max_benefits) > 0:
-			frappe.throw(
-				_("Salary Structure should have flexible benefit component(s) to dispense benefit amount")
-			)
-
 	def get_employees(self, **kwargs):
-		conditions, values = [], []
+		Employee = frappe.qb.DocType("Employee")
+		query = frappe.qb.from_(Employee).select(Employee.name).where(Employee.status == "Active")
 		for field, value in kwargs.items():
 			if value:
-				conditions.append(f"{field}=%s")
-				values.append(value)
+				query = query.where(Employee[field] == value)
 
-		condition_str = " and " + " and ".join(conditions) if conditions else ""
-
-		# nosemgrep: frappe-semgrep-rules.rules.frappe-using-db-sql
-		employees = frappe.db.sql_list(
-			f"select name from tabEmployee where status='Active' {condition_str}",
-			tuple(values),
-		)
+		employees = query.run(pluck="name")
 
 		return employees
 
 	@frappe.whitelist()
 	def assign_salary_structure(
 		self,
-		branch=None,
-		grade=None,
-		department=None,
-		designation=None,
-		employee=None,
-		payroll_payable_account=None,
-		from_date=None,
-		base=None,
-		variable=None,
-		income_tax_slab=None,
-	):
+		branch: str | None = None,
+		grade: str | None = None,
+		department: str | None = None,
+		designation: str | None = None,
+		employee: str | None = None,
+		payroll_payable_account: str | None = None,
+		from_date: str | None = None,
+		base: float | None = None,
+		variable: float | None = None,
+		income_tax_slab: str | None = None,
+	) -> None:
 		employees = self.get_employees(
 			company=self.company,
 			grade=grade,
@@ -337,15 +340,19 @@ def create_salary_structure_assignment(
 
 
 def get_existing_assignments(employees, salary_structure, from_date):
-	# nosemgrep: frappe-semgrep-rules.rules.frappe-using-db-sql
-	salary_structures_assignments = frappe.db.sql_list(
-		f"""
-		SELECT DISTINCT employee FROM `tabSalary Structure Assignment`
-		WHERE salary_structure=%s AND employee IN ({", ".join(["%s"] * len(employees))})
-		AND from_date=%s AND company=%s AND docstatus=1
-		""",
-		[salary_structure.name, *employees, from_date, salary_structure.company],
-	)
+	ssa = frappe.qb.DocType("Salary Structure Assignment")
+	salary_structures_assignments = (
+		frappe.qb.from_(ssa)
+		.select(ssa.employee)
+		.distinct()
+		.where(
+			(ssa.salary_structure == salary_structure.name)
+			& (ssa.employee.isin(employees))
+			& (ssa.from_date == from_date)
+			& (ssa.company == salary_structure.company)
+			& (ssa.docstatus == 1)
+		)
+	).run(pluck="employee")
 	if salary_structures_assignments:
 		frappe.msgprint(
 			_(
@@ -357,22 +364,50 @@ def get_existing_assignments(employees, salary_structure, from_date):
 
 @frappe.whitelist()
 def make_salary_slip(
-	source_name,
-	target_doc=None,
-	employee=None,
-	posting_date=None,
-	as_print=False,
-	print_format=None,
-	for_preview=0,
-	ignore_permissions=False,
-):
+	source_name: str,
+	target_doc: str | Document | None = None,
+	employee: str | None = None,
+	posting_date: str | datetime.date | None = None,
+	as_print: bool = False,
+	print_format: str | None = None,
+	for_preview: int = 0,
+	lwp_days_corrected: float | None = None,
+) -> str | Document:
+	if employee:
+		frappe.has_permission("Employee", "read", employee, throw=True)
+
+	return _make_salary_slip(
+		source_name,
+		target_doc=target_doc,
+		employee=employee,
+		posting_date=posting_date,
+		as_print=as_print,
+		print_format=print_format,
+		for_preview=for_preview,
+		lwp_days_corrected=lwp_days_corrected,
+	)
+
+
+def _make_salary_slip(
+	source_name: str,
+	target_doc: str | Document | None = None,
+	employee: str | None = None,
+	posting_date: str | datetime.date | None = None,
+	as_print: bool = False,
+	print_format: str | None = None,
+	for_preview: int = 0,
+	lwp_days_corrected: float | None = None,
+	ignore_permissions: bool = False,
+) -> str | Document:
 	def postprocess(source, target):
 		if employee:
 			target.employee = employee
 			if posting_date:
 				target.posting_date = posting_date
 
-		target.run_method("process_salary_structure", for_preview=for_preview)
+		target.run_method(
+			"process_salary_structure", for_preview=for_preview, lwp_days_corrected=lwp_days_corrected
+		)
 
 	doc = get_mapped_doc(
 		"Salary Structure",
@@ -389,8 +424,8 @@ def make_salary_slip(
 		},
 		target_doc,
 		postprocess,
-		ignore_child_tables=True,
 		ignore_permissions=ignore_permissions,
+		ignore_child_tables=True,
 		cached=True,
 	)
 
@@ -402,7 +437,7 @@ def make_salary_slip(
 
 
 @frappe.whitelist()
-def get_employees(salary_structure):
+def get_employees(salary_structure: str) -> list[str]:
 	employees = frappe.get_list(
 		"Salary Structure Assignment",
 		filters={"salary_structure": salary_structure, "docstatus": 1},
@@ -420,7 +455,9 @@ def get_employees(salary_structure):
 
 
 @frappe.whitelist()
-def get_salary_component(doctype, txt, searchfield, start, page_len, filters):
+def get_salary_component(
+	doctype: str, txt: str, searchfield: str, start: int, page_len: int, filters: dict
+) -> list:
 	sc = frappe.qb.DocType("Salary Component")
 	sca = frappe.qb.DocType("Salary Component Account")
 
@@ -447,3 +484,44 @@ def get_salary_component(doctype, txt, searchfield, start, page_len, filters):
 				accounts.append((component.name, component.account, component.company))
 
 	return accounts
+
+
+def validate_max_benefit_for_flexible_benefit(employee_benefits, max_benefits=None):
+	if not employee_benefits:
+		return
+
+	benefit_total = 0
+	benefit_components = []
+
+	for benefit in employee_benefits:
+		if benefit.salary_component in benefit_components:
+			frappe.throw(
+				_("Salary Component {0} cannot be selected more than once in Employee Benefits").format(
+					benefit.salary_component
+				)
+			)
+
+		benefit_total += benefit.amount
+		max_of_component = frappe.db.get_value(
+			"Salary Component", benefit.salary_component, "max_benefit_amount"
+		)
+		if max_of_component and max_of_component > 0 and benefit.amount > max_of_component:
+			frappe.throw(
+				_(
+					"Benefit amount {0} for Salary Component {1} should not be greater than maximum benefit amount {2} set in {3}"
+				).format(
+					benefit.amount,
+					benefit.salary_component,
+					max_of_component,
+					get_link_to_form("Salary Component", benefit.salary_component),
+				)
+			)
+		benefit_components.append(benefit.salary_component)
+
+	if max_benefits and benefit_total > max_benefits:
+		frappe.throw(
+			_("Total of all employee benefits cannot be greater that Max Benefits Amount {0}").format(
+				max_benefits
+			),
+			title=_("Invalid Benefit Amounts"),
+		)

--- a/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+++ b/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
@@ -22,13 +22,20 @@
   "currency",
   "section_break_7",
   "base",
+  "annual_gross_earning",
   "column_break_9",
   "variable",
+  "ctc",
   "amended_from",
+  "column_break_kjvm",
+  "leave_encashment_amount_per_day",
   "opening_balances_section",
   "taxable_earnings_till_date",
   "column_break_20",
   "tax_deducted_till_date",
+  "employee_benefits_section",
+  "max_benefits",
+  "employee_benefits",
   "section_break_17",
   "payroll_cost_centers"
  ],
@@ -101,7 +108,7 @@
   {
    "fieldname": "section_break_7",
    "fieldtype": "Section Break",
-   "label": "Base & Variable"
+   "label": "Base, Variable & Leave Encashment"
   },
   {
    "fetch_from": "grade.default_base_pay",
@@ -110,6 +117,20 @@
    "fieldtype": "Currency",
    "label": "Base",
    "options": "currency"
+  },
+  {
+   "fieldname": "annual_gross_earning",
+   "fieldtype": "Currency",
+   "label": "Annual Gross Earning",
+   "options": "currency",
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "ctc",
+   "fieldtype": "Currency",
+   "label": "Total Cost To Company (CTC)",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_9",
@@ -206,15 +227,46 @@
    "fieldtype": "Section Break",
    "hidden": 1,
    "label": "Opening Balances"
+  },
+  {
+   "fieldname": "employee_benefits_section",
+   "fieldtype": "Section Break",
+   "label": "Employee Benefits"
+  },
+  {
+   "fieldname": "employee_benefits",
+   "fieldtype": "Table",
+   "label": "Flexible Benefits",
+   "options": "Employee Benefit Detail"
+  },
+  {
+   "fetch_from": "salary_structure.max_benefits",
+   "fetch_if_empty": 1,
+   "fieldname": "max_benefits",
+   "fieldtype": "Currency",
+   "label": "Maximum Benefit Amount",
+   "options": "currency"
+  },
+  {
+   "fieldname": "column_break_kjvm",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "salary_structure.leave_encashment_amount_per_day",
+   "fetch_if_empty": 1,
+   "fieldname": "leave_encashment_amount_per_day",
+   "fieldtype": "Currency",
+   "label": "Leave Encashment Amount Per Day",
+   "options": "currency"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2024-10-18 18:06:42.013701",
+ "modified": "2026-06-08 17:40:49.118187",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Structure Assignment",
- "naming_rule": "Expression (old style)",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {
@@ -255,8 +307,14 @@
    "share": 1,
    "submit": 1,
    "write": 1
+  },
+  {
+   "read": 1,
+   "role": "Employee",
+   "select": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "employee_name, salary_structure",
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
+++ b/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
@@ -5,9 +5,43 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import cint, flt, get_link_to_form, getdate
+from frappe.utils import cint, date_diff, flt, get_link_to_form, getdate
 
 from hrms.payroll.doctype.payroll_period.payroll_period import get_payroll_period
+from hrms.payroll.doctype.salary_structure.salary_structure import validate_max_benefit_for_flexible_benefit
+from hrms.payroll.utils import (
+	COMPONENT_EVAL_GLOBALS,
+	_safe_eval,
+	get_component_eval_context,
+	sanitize_expression,
+	throw_error_message,
+)
+
+# Fields copied from the salary structure component row onto each evaluated row
+# handed to the salary slip. The slip reads these to build/identify slip rows.
+SALARY_COMPONENT_FLAGS = (
+	"salary_component",
+	"abbr",
+	"amount_based_on_formula",
+	"statistical_component",
+	"accrual_component",
+	"depends_on_payment_days",
+	"do_not_include_in_total",
+	"do_not_include_in_accounts",
+	"is_tax_applicable",
+	"is_flexible_benefit",
+	"variable_based_on_taxable_salary",
+	"exempted_from_income_tax",
+	"deduct_full_tax_on_selected_payroll_date",
+)
+
+PERIODS_PER_YEAR = {
+	"Monthly": 12,
+	"Fortnightly": 26,
+	"Bimonthly": 24,
+	"Weekly": 52,
+	"Daily": 365,
+}
 
 
 class DuplicateAssignment(frappe.ValidationError):
@@ -15,17 +49,54 @@ class DuplicateAssignment(frappe.ValidationError):
 
 
 class SalaryStructureAssignment(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from hrms.payroll.doctype.employee_benefit_detail.employee_benefit_detail import EmployeeBenefitDetail
+		from hrms.payroll.doctype.employee_cost_center.employee_cost_center import EmployeeCostCenter
+
+		amended_from: DF.Link | None
+		annual_gross_earning: DF.Currency
+		base: DF.Currency
+		company: DF.Link
+		ctc: DF.Currency
+		currency: DF.Link
+		department: DF.Link | None
+		designation: DF.Link | None
+		employee: DF.Link
+		employee_benefits: DF.Table[EmployeeBenefitDetail]
+		employee_name: DF.Data | None
+		from_date: DF.Date
+		grade: DF.Link | None
+		income_tax_slab: DF.Link | None
+		leave_encashment_amount_per_day: DF.Currency
+		max_benefits: DF.Currency
+		payroll_cost_centers: DF.Table[EmployeeCostCenter]
+		payroll_payable_account: DF.Link | None
+		salary_structure: DF.Link
+		tax_deducted_till_date: DF.Currency
+		taxable_earnings_till_date: DF.Currency
+		variable: DF.Currency
+	# end: auto-generated types
+
 	def validate(self):
 		self.validate_dates()
 		self.validate_company()
 		self.validate_income_tax_slab()
 		self.set_payroll_payable_account()
+		validate_max_benefit_for_flexible_benefit(self.employee_benefits, self.max_benefits)
 
 		if not self.get("payroll_cost_centers"):
 			self.set_payroll_cost_centers()
 
 		self.validate_cost_centers()
 		self.warn_about_missing_opening_entries()
+		self.calculate_ctc_and_gross()
 
 	def on_update_after_submit(self):
 		self.validate_cost_centers()
@@ -112,7 +183,7 @@ class SalaryStructureAssignment(Document):
 			self.payroll_payable_account = payroll_payable_account
 
 	@frappe.whitelist()
-	def set_payroll_cost_centers(self):
+	def set_payroll_cost_centers(self) -> None:
 		self.payroll_cost_centers = []
 		default_payroll_cost_center = self.get_payroll_cost_center()
 		if default_payroll_cost_center:
@@ -153,9 +224,7 @@ class SalaryStructureAssignment(Document):
 			and not self.taxable_earnings_till_date
 			and not self.tax_deducted_till_date
 		):
-			msg = _("Could not find any salary slip(s) for the employee {0}").format(self.employee)
-			msg += "<br><br>"
-			msg += _(
+			msg = _(
 				"Please specify {0} and {1} (if any), for the correct tax calculation in future salary slips."
 			).format(
 				frappe.bold(_("Taxable Earnings Till Date")),
@@ -167,59 +236,228 @@ class SalaryStructureAssignment(Document):
 				title=_("Missing Opening Entries"),
 			)
 
+	def get_evaluated_components(self) -> frappe._dict:
+		"""Evaluate all salary structure components for this assignment and return
+		fully-evaluated rows the salary slip can consume directly.
+
+		Earnings, deductions and employer contributions are evaluated in one
+		shared pass (so a deduction formula can reference an earning abbr), each
+		row carrying its full-cycle ``default_amount`` plus the flags the slip
+		needs. This is period-independent: the (period-dependent) timesheet wage
+		is built by the salary slip itself, not here. The slip consumes
+		``default_amount`` directly and applies payment-days proration / tax on
+		top (it re-evaluates each formula once against its prorated context for
+		the actual ``amount``).
+		"""
+		_data, rows_by_type = self._evaluate_all_components()
+
+		return frappe._dict(
+			earnings=rows_by_type["earnings"],
+			deductions=rows_by_type["deductions"],
+			employer_contributions=rows_by_type["employer_contributions"],
+		)
+
+	def get_timesheet_config(self) -> frappe._dict:
+		"""Lightweight read of the linked structure's timesheet settings, needed
+		by the slip early (before component evaluation runs)."""
+		ss = (
+			frappe.get_cached_value(
+				"Salary Structure",
+				self.salary_structure,
+				["salary_slip_based_on_timesheet", "hour_rate", "salary_component"],
+				as_dict=True,
+			)
+			or frappe._dict()
+		)
+		return frappe._dict(
+			based_on_timesheet=cint(ss.salary_slip_based_on_timesheet),
+			hour_rate=flt(ss.hour_rate),
+			timesheet_component=ss.salary_component,
+		)
+
+	def calculate_ctc_and_gross(self) -> None:
+		if not self.base or not self.salary_structure:
+			self.annual_gross_earning = 0
+			self.ctc = 0
+			return
+
+		salary_structure = frappe.get_cached_doc("Salary Structure", self.salary_structure)
+		periods = PERIODS_PER_YEAR.get(salary_structure.payroll_frequency, 12)
+
+		data, rows_by_type = self._evaluate_all_components()
+
+		# Reuse the per-period gross already computed in the eval context: payable
+		# earnings only (excludes statistical and do_not_include_in_total), matching
+		# the salary slip's gross_pay.
+		gross_per_period = flt(data.get("gross_pay"))
+
+		# CTC also includes costs that are part of CTC but not payable: do_not_include_in_total
+		# earnings (shown on the slip, excluded from gross) and employer contributions (off-slip).
+		non_payable_earnings_per_period = sum(
+			flt(r.default_amount)
+			for r in rows_by_type["earnings"]
+			if not r.statistical_component and r.do_not_include_in_total
+		)
+		employer_per_period = sum(
+			flt(r.default_amount)
+			for r in rows_by_type["employer_contributions"]
+			if not r.statistical_component
+		)
+
+		self.annual_gross_earning = flt(gross_per_period * periods, self.precision("annual_gross_earning"))
+		self.ctc = flt(
+			(gross_per_period + non_payable_earnings_per_period + employer_per_period) * periods,
+			self.precision("ctc"),
+		)
+
+	def _evaluate_all_components(self) -> tuple[frappe._dict, dict]:
+		"""Single shared-context pass over earnings -> deductions ->
+		employer_contributions. Returns the final context and evaluated rows by
+		type. Does not mutate the cached salary structure doc."""
+		salary_structure = frappe.get_cached_doc("Salary Structure", self.salary_structure)
+		data = self._get_component_eval_context()
+
+		rows_by_type = {}
+		rows_by_type["earnings"] = self._evaluate_component_table(
+			salary_structure.get("earnings") or [], data
+		)
+
+		# Expose full-cycle gross_pay so deduction / employer-contribution formulas can
+		# reference it (e.g. PF, ESI), mirroring how the salary slip sets gross_pay after
+		# earnings and before deductions.
+		data["gross_pay"] = sum(
+			flt(r.default_amount)
+			for r in rows_by_type["earnings"]
+			if not r.statistical_component and not r.do_not_include_in_total
+		)
+
+		rows_by_type["deductions"] = self._evaluate_component_table(
+			salary_structure.get("deductions") or [], data
+		)
+		rows_by_type["employer_contributions"] = self._evaluate_component_table(
+			salary_structure.get("employer_contributions") or [], data
+		)
+		return data, rows_by_type
+
+	def _get_component_eval_context(self) -> frappe._dict:
+		from hrms.payroll.doctype.payroll_entry.payroll_entry import get_start_end_dates
+
+		data = get_component_eval_context(self.employee, self.as_dict())
+
+		# The SSA has no salary slip, so formulas referencing slip period fields (e.g.
+		# start_date) would raise NameError. Seed a full cycle -- the period containing
+		# from_date -- with no LWP/absence so proration-based formulas yield full-cycle
+		# values (payment_days == total_working_days, ratio 1).
+		frequency = frappe.get_cached_value("Salary Structure", self.salary_structure, "payroll_frequency")
+		dates = get_start_end_dates(frequency, self.from_date, self.company)
+		period_days = date_diff(dates.end_date, dates.start_date) + 1
+		data.start_date = dates.start_date
+		data.end_date = dates.end_date
+		data.payment_days = period_days
+		data.total_working_days = period_days
+		data.leave_without_pay = 0
+		data.absent_days = 0
+		data.unmarked_days = 0
+		return data
+
+	def _evaluate_component_table(self, rows, data: frappe._dict) -> list:
+		"""Evaluate one component table against the shared ``data`` (mutating it
+		with each component's full-cycle amount). Returns fresh ``frappe._dict``
+		rows (cache-safe copies). Raises a clear error on a bad formula/condition.
+		Rows whose condition is falsey are skipped (not added to the slip)."""
+		evaluated_components = []
+		for struct_row in rows:
+			condition = sanitize_expression(struct_row.condition)
+			formula = sanitize_expression(struct_row.formula)
+			amount = flt(struct_row.amount)
+
+			try:
+				if condition and not _safe_eval(condition, COMPONENT_EVAL_GLOBALS.copy(), data):
+					continue
+				if struct_row.amount_based_on_formula and formula:
+					default_amount = flt(
+						_safe_eval(formula, COMPONENT_EVAL_GLOBALS.copy(), data),
+						struct_row.precision("amount"),
+					)
+				else:
+					default_amount = amount
+			except NameError as ne:
+				throw_error_message(
+					struct_row,
+					ne,
+					title=_("Name error"),
+					description=_("This error can be due to missing or deleted field."),
+				)
+			except SyntaxError as se:
+				throw_error_message(
+					struct_row,
+					se,
+					title=_("Syntax error"),
+					description=_("This error can be due to invalid syntax."),
+				)
+			except Exception as exc:
+				throw_error_message(
+					struct_row,
+					exc,
+					title=_("Error in formula or condition"),
+					description=_("This error can be due to invalid formula or condition."),
+				)
+				raise
+
+			data[struct_row.abbr] = default_amount
+
+			evaluated_component_row = frappe._dict(
+				default_amount=default_amount,
+				amount=amount,
+				condition=condition,
+				formula=formula,
+				precision=struct_row.precision("amount"),
+			)
+			for field in SALARY_COMPONENT_FLAGS:
+				evaluated_component_row[field] = struct_row.get(field)
+			evaluated_components.append(evaluated_component_row)
+
+		return evaluated_components
+
 	@frappe.whitelist()
 	def are_opening_entries_required(self) -> bool:
 		if not get_tax_component(self.salary_structure):
 			return False
 
-		if self.has_emp_joined_after_payroll_period_start() and not self.has_existing_salary_slips():
-			return True
-		else:
-			if not self.docstatus.is_draft() and (
-				self.taxable_earnings_till_date or self.tax_deducted_till_date
-			):
-				return True
+		payroll_period = get_payroll_period(self.from_date, self.from_date, self.company)
+		if payroll_period and getdate(self.from_date) <= getdate(payroll_period.start_date):
 			return False
 
-	def has_existing_salary_slips(self) -> bool:
-		return bool(
-			frappe.db.exists(
-				"Salary Slip",
-				{"employee": self.employee, "docstatus": 1},
-			)
-		)
-
-	def has_emp_joined_after_payroll_period_start(self) -> bool:
-		date_of_joining = getdate(frappe.db.get_value("Employee", self.employee, "date_of_joining"))
-		payroll_period = get_payroll_period(self.from_date, self.from_date, self.company)
-		if not payroll_period or date_of_joining > getdate(payroll_period.start_date):
-			return True
-		return False
+		return True
 
 
 def get_assigned_salary_structure(employee, on_date):
 	if not employee or not on_date:
 		return None
-	salary_structure = frappe.db.sql(
-		"""
-		select salary_structure from `tabSalary Structure Assignment`
-		where employee=%(employee)s
-		and docstatus = 1
-		and %(on_date)s >= from_date order by from_date desc limit 1""",
-		{
-			"employee": employee,
-			"on_date": on_date,
-		},
+
+	salary_structure_assignment = frappe.qb.DocType("Salary Structure Assignment")
+
+	query = (
+		frappe.qb.from_(salary_structure_assignment)
+		.select(salary_structure_assignment.salary_structure)
+		.where(salary_structure_assignment.employee == employee)
+		.where(salary_structure_assignment.docstatus == 1)
+		.where(on_date >= salary_structure_assignment.from_date)
+		.orderby(salary_structure_assignment.from_date, order=frappe.qb.desc)
+		.limit(1)
 	)
-	return salary_structure[0][0] if salary_structure else None
+
+	result = query.run()
+	return result[0][0] if result else None
 
 
 @frappe.whitelist()
-def get_employee_currency(employee):
+def get_employee_currency(employee: str) -> str:
+	frappe.has_permission("Employee", "read", employee, throw=True)
 	employee_currency = frappe.db.get_value("Salary Structure Assignment", {"employee": employee}, "currency")
 	if not employee_currency:
 		frappe.throw(
-			_("There is no Salary Structure assigned to {0}. First assign a Salary Stucture.").format(
+			_("There is no Salary Structure assigned to {0}. First assign a Salary Structure.").format(
 				employee
 			)
 		)

--- a/hrms/payroll/doctype/salary_structure_assignment/test_salary_structure_assignment.py
+++ b/hrms/payroll/doctype/salary_structure_assignment/test_salary_structure_assignment.py
@@ -1,8 +1,284 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-from frappe.tests import IntegrationTestCase
+import frappe
+from frappe.utils import get_first_day, nowdate
+
+from erpnext.setup.doctype.employee.test_employee import make_employee
+
+from hrms.payroll.doctype.salary_structure.test_salary_structure import make_salary_structure
+from hrms.tests.utils import HRMSTestSuite
 
 
-class TestSalaryStructureAssignment(IntegrationTestCase):
-	pass
+def _make_component(name, abbr, comp_type="Earning", **flags):
+	if frappe.db.exists("Salary Component", name):
+		frappe.delete_doc("Salary Component", name, force=True)
+	doc = frappe.new_doc("Salary Component")
+	doc.update({"salary_component": name, "salary_component_abbr": abbr, "type": comp_type})
+	doc.update(flags)
+	return doc.insert()
+
+
+class TestSalaryStructureAssignment(HRMSTestSuite):
+	def test_ctc_and_annual_gross_exclude_statistical_and_include_employer(self):
+		"""base=50000; gross = Basic (50000) only - statistical earning (1000) is
+		excluded; CTC = gross + employer contribution (6000)."""
+		emp = make_employee("ssa_ctc_calc@test.com", company="_Test Company")
+
+		_make_component("SSA Test Basic", "SSATB", "Earning", amount_based_on_formula=1, formula="base")
+		_make_component("SSA Test Statistical", "SSATS", "Earning", statistical_component=1)
+		_make_component("SSA Test Employer PF", "SSATEPF", "Employer Contribution")
+
+		earnings = [
+			{
+				"salary_component": "SSA Test Basic",
+				"abbr": "SSATB",
+				"amount_based_on_formula": 1,
+				"formula": "base",
+			},
+			{
+				"salary_component": "SSA Test Statistical",
+				"abbr": "SSATS",
+				"statistical_component": 1,
+				"amount": 1000,
+			},
+		]
+		employer_contributions = [
+			{"salary_component": "SSA Test Employer PF", "abbr": "SSATEPF", "amount": 6000},
+		]
+
+		make_salary_structure(
+			"SSA Test CTC Structure",
+			"Monthly",
+			employee=emp,
+			company="_Test Company",
+			base=50000,
+			earnings=earnings,
+			deductions=[],
+			other_details={"employer_contributions": employer_contributions},
+		)
+		ssa = frappe.get_last_doc("Salary Structure Assignment", filters={"employee": emp})
+
+		self.assertEqual(ssa.annual_gross_earning, 50000 * 12)
+		self.assertEqual(ssa.ctc, (50000 + 6000) * 12)
+
+	def test_ctc_reset_when_base_missing(self):
+		emp = make_employee("ssa_ctc_nobase@test.com", company="_Test Company")
+		make_salary_structure("SSA Test No Base Structure", "Monthly", company="_Test Company")
+		ssa = frappe.new_doc("Salary Structure Assignment")
+		ssa.employee = emp
+		ssa.salary_structure = "SSA Test No Base Structure"
+		ssa.company = "_Test Company"
+		ssa.from_date = get_first_day(nowdate())
+		ssa.base = 0
+		ssa.calculate_ctc_and_gross()
+		self.assertEqual(ssa.ctc, 0)
+		self.assertEqual(ssa.annual_gross_earning, 0)
+
+	def test_get_evaluated_components_does_not_mutate_cached_structure(self):
+		emp = make_employee("ssa_cache@test.com", company="_Test Company")
+		make_salary_structure(
+			"SSA Test Cache Structure", "Monthly", employee=emp, company="_Test Company", base=50000
+		)
+		ssa = frappe.get_last_doc("Salary Structure Assignment", filters={"employee": emp})
+
+		ssa.get_evaluated_components()
+		# the cached Salary Structure doc's earning rows must not carry a stamped default_amount
+		cached = frappe.get_cached_doc("Salary Structure", "SSA Test Cache Structure")
+		self.assertTrue(all(not r.get("default_amount") for r in cached.earnings))
+
+	def test_get_evaluated_components_resolves_salary_slip_fields(self):
+		"""A component formula may reference any salary slip field (e.g. start_date),
+		since the slip evaluates formulas against its own as_dict. SSA evaluation has
+		no slip, so it must mirror a full-cycle preview slip's field set; otherwise the
+		formula raises a NameError on the missing slip field."""
+		emp = make_employee("ssa_slip_field@test.com", company="_Test Company")
+
+		# formula references start_date -- a salary-slip field, absent from the SSA itself
+		formula = "base * getdate(start_date).month"
+		_make_component(
+			"SSA Test Period Bonus", "SSATPB", "Earning", amount_based_on_formula=1, formula=formula
+		)
+		earnings = [
+			{
+				"salary_component": "SSA Test Period Bonus",
+				"abbr": "SSATPB",
+				"amount_based_on_formula": 1,
+				"formula": formula,
+			},
+		]
+
+		make_salary_structure(
+			"SSA Test Slip Field Structure",
+			"Monthly",
+			employee=emp,
+			company="_Test Company",
+			base=1000,
+			earnings=earnings,
+			deductions=[],
+		)
+		ssa = frappe.get_last_doc("Salary Structure Assignment", filters={"employee": emp})
+
+		# full-cycle start_date is the first of the SSA's from_date month, so the
+		# component resolves to base * that month (proving start_date was seeded correctly)
+		expected = 1000 * get_first_day(ssa.from_date).month
+		components = {r.salary_component: r.default_amount for r in ssa.get_evaluated_components().earnings}
+		self.assertEqual(components["SSA Test Period Bonus"], expected)
+
+	def test_get_evaluated_components_resolves_uncovered_slip_fields(self):
+		emp = make_employee("ssa_uncovered_field@test.com", company="_Test Company")
+
+		condition = "gross_year_to_date < 74600"
+		formula = "base + gross_year_to_date + month_to_date + year_to_date + unmarked_days"
+		_make_component(
+			"SSA Test Basic YTD", "SSATBYTD", "Earning", amount_based_on_formula=1, formula="base"
+		)
+		_make_component(
+			"SSA Test YTD Guard", "SSATYG", "Deduction", amount_based_on_formula=1, formula=formula
+		)
+
+		earnings = [
+			{
+				"salary_component": "SSA Test Basic YTD",
+				"abbr": "SSATBYTD",
+				"amount_based_on_formula": 1,
+				"formula": "base",
+			},
+		]
+		deductions = [
+			{
+				"salary_component": "SSA Test YTD Guard",
+				"abbr": "SSATYG",
+				"amount_based_on_formula": 1,
+				"formula": formula,
+				"condition": condition,
+			},
+		]
+
+		make_salary_structure(
+			"SSA Test Uncovered Field Structure",
+			"Monthly",
+			employee=emp,
+			company="_Test Company",
+			base=50000,
+			earnings=earnings,
+			deductions=deductions,
+		)
+		ssa = frappe.get_last_doc("Salary Structure Assignment", filters={"employee": emp})
+
+		components = {r.salary_component: r.default_amount for r in ssa.get_evaluated_components().deductions}
+		self.assertEqual(components["SSA Test YTD Guard"], 50000)
+
+	def test_do_not_include_in_total_earning_is_in_ctc_but_not_gross(self):
+		"""A 'Do Not Include in Total' earning is part of CTC but not payable - it
+		must be excluded from annual_gross_earning yet included in ctc."""
+		emp = make_employee("ssa_dniit@test.com", company="_Test Company")
+
+		_make_component("SSA Test Basic Pay", "SSATBP", "Earning", amount_based_on_formula=1, formula="base")
+		_make_component("SSA Test Company Car", "SSATCAR", "Earning", do_not_include_in_total=1)
+
+		earnings = [
+			{
+				"salary_component": "SSA Test Basic Pay",
+				"abbr": "SSATBP",
+				"amount_based_on_formula": 1,
+				"formula": "base",
+			},
+			{
+				"salary_component": "SSA Test Company Car",
+				"abbr": "SSATCAR",
+				"amount": 2000,
+				"do_not_include_in_total": 1,
+			},
+		]
+
+		make_salary_structure(
+			"SSA Test DNIIT Structure",
+			"Monthly",
+			employee=emp,
+			company="_Test Company",
+			base=50000,
+			earnings=earnings,
+			deductions=[],
+		)
+		ssa = frappe.get_last_doc("Salary Structure Assignment", filters={"employee": emp})
+
+		self.assertEqual(ssa.annual_gross_earning, 50000 * 12)
+		self.assertEqual(ssa.ctc, (50000 + 2000) * 12)
+
+	def test_ctc_for_timesheet_structure_evaluates_base_driven_components(self):
+		"""For a timesheet-based structure, only the wage component is paid as
+		hour_rate * hours (variable, excluded from CTC). The rest of the structure
+		(base-driven components) must still evaluate normally into gross / ctc."""
+		emp = make_employee("ssa_ts_ctc@test.com", company="_Test Company")
+
+		# wage component is the structure-level timesheet component, NOT an earning row
+		_make_component("SSA TS Wage", "SSATSW", "Earning")
+		_make_component("SSA TS Basic", "SSATSB", "Earning", amount_based_on_formula=1, formula="base")
+
+		earnings = [
+			{
+				"salary_component": "SSA TS Basic",
+				"abbr": "SSATSB",
+				"amount_based_on_formula": 1,
+				"formula": "base",
+			},
+		]
+
+		make_salary_structure(
+			"SSA Timesheet Structure",
+			"Monthly",
+			employee=emp,
+			company="_Test Company",
+			base=50000,
+			earnings=earnings,
+			deductions=[],
+			other_details={
+				"salary_slip_based_on_timesheet": 1,
+				"hour_rate": 50,
+				"salary_component": "SSA TS Wage",
+			},
+		)
+		ssa = frappe.get_last_doc("Salary Structure Assignment", filters={"employee": emp})
+
+		# base-driven earning evaluates normally; the variable hourly wage is excluded from CTC
+		self.assertEqual(ssa.annual_gross_earning, 50000 * 12)
+		self.assertEqual(ssa.ctc, 50000 * 12)
+
+	def test_get_evaluated_components_excludes_timesheet_wage(self):
+		"""SSA evaluation is period-independent: the timesheet wage (hour_rate * hours)
+		is built by the salary slip, not SSA. get_evaluated_components must return only
+		the structure's declared components, never an injected wage row."""
+		emp = make_employee("ssa_ts_eval@test.com", company="_Test Company")
+
+		_make_component("SSA TS2 Wage", "SSATS2W", "Earning")
+		_make_component("SSA TS2 Basic", "SSATS2B", "Earning", amount_based_on_formula=1, formula="base")
+
+		earnings = [
+			{
+				"salary_component": "SSA TS2 Basic",
+				"abbr": "SSATS2B",
+				"amount_based_on_formula": 1,
+				"formula": "base",
+			},
+		]
+
+		make_salary_structure(
+			"SSA Timesheet Eval Structure",
+			"Monthly",
+			employee=emp,
+			company="_Test Company",
+			base=50000,
+			earnings=earnings,
+			deductions=[],
+			other_details={
+				"salary_slip_based_on_timesheet": 1,
+				"hour_rate": 50,
+				"salary_component": "SSA TS2 Wage",
+			},
+		)
+		ssa = frappe.get_last_doc("Salary Structure Assignment", filters={"employee": emp})
+
+		components = [r.salary_component for r in ssa.get_evaluated_components().earnings]
+		self.assertNotIn("SSA TS2 Wage", components)
+		self.assertIn("SSA TS2 Basic", components)

--- a/hrms/payroll/doctype/salary_withholding/salary_withholding.py
+++ b/hrms/payroll/doctype/salary_withholding/salary_withholding.py
@@ -12,6 +12,34 @@ from frappe.utils import add_days, add_to_date, cint, get_link_to_form, getdate
 
 
 class SalaryWithholding(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from hrms.payroll.doctype.salary_withholding_cycle.salary_withholding_cycle import (
+			SalaryWithholdingCycle,
+		)
+
+		amended_from: DF.Link | None
+		company: DF.Link | None
+		cycles: DF.Table[SalaryWithholdingCycle]
+		date_of_joining: DF.Date | None
+		employee: DF.Link
+		employee_name: DF.Data | None
+		from_date: DF.Date
+		number_of_withholding_cycles: DF.Int
+		payroll_frequency: DF.Literal["", "Monthly", "Fortnightly", "Bimonthly", "Weekly", "Daily"]
+		posting_date: DF.Date
+		reason_for_withholding_salary: DF.SmallText | None
+		relieving_date: DF.Date | None
+		status: DF.Literal["", "Draft", "Withheld", "Released", "Cancelled"]
+		to_date: DF.Date
+	# end: auto-generated types
+
 	def validate(self):
 		if not self.payroll_frequency:
 			self.payroll_frequency = get_payroll_frequency(self.employee, self.from_date)
@@ -60,7 +88,7 @@ class SalaryWithholding(Document):
 			self.status = status
 
 	@frappe.whitelist()
-	def set_withholding_cycles_and_to_date(self):
+	def set_withholding_cycles_and_to_date(self) -> None:
 		self.to_date = self.get_to_date()
 
 		cycle_from_date = cycle_to_date = getdate(self.from_date)
@@ -97,9 +125,13 @@ class SalaryWithholding(Document):
 		}
 		return frequency_dict.get(self.payroll_frequency)
 
+	def on_discard(self):
+		self.db_set("status", "Cancelled")
+
 
 @frappe.whitelist()
 def get_payroll_frequency(employee: str, posting_date: str | date) -> str | None:
+	frappe.has_permission("Employee", "read", employee, throw=True)
 	salary_structure = frappe.db.get_value(
 		"Salary Structure Assignment",
 		{

--- a/hrms/payroll/report/income_tax_computation/test_income_tax_computation.py
+++ b/hrms/payroll/report/income_tax_computation/test_income_tax_computation.py
@@ -1,6 +1,5 @@
 import frappe
-from frappe.tests import IntegrationTestCase
-from frappe.utils import getdate
+from frappe.utils import add_days, getdate
 
 from erpnext.setup.doctype.employee.test_employee import make_employee
 
@@ -14,25 +13,24 @@ from hrms.payroll.doctype.salary_slip.test_salary_slip import (
 )
 from hrms.payroll.doctype.salary_structure.test_salary_structure import make_salary_structure
 from hrms.payroll.report.income_tax_computation.income_tax_computation import execute
+from hrms.tests.utils import HRMSTestSuite
 
 
-class TestIncomeTaxComputation(IntegrationTestCase):
+class TestIncomeTaxComputation(HRMSTestSuite):
 	def setUp(self):
 		self.cleanup_records()
 		self.create_records()
 
-	def tearDown(self):
-		frappe.db.rollback()
-
 	def cleanup_records(self):
-		frappe.db.sql("delete from `tabEmployee Tax Exemption Declaration`")
-		frappe.db.sql("delete from `tabPayroll Period`")
-		frappe.db.sql("delete from `tabIncome Tax Slab`")
-		frappe.db.sql("delete from `tabSalary Component`")
-		frappe.db.sql("delete from `tabEmployee Benefit Application`")
-		frappe.db.sql("delete from `tabEmployee Benefit Claim`")
-		frappe.db.sql("delete from `tabEmployee` where company='_Test Company'")
-		frappe.db.sql("delete from `tabSalary Slip`")
+		frappe.qb.from_("Employee Tax Exemption Declaration").delete().run()
+		frappe.qb.from_("Payroll Period").delete().run()
+		frappe.qb.from_("Income Tax Slab").delete().run()
+		frappe.qb.from_("Salary Component").delete().run()
+		frappe.qb.from_("Employee Benefit Application").delete().run()
+		frappe.qb.from_("Employee Benefit Claim").delete().run()
+		employee = frappe.qb.DocType("Employee")
+		frappe.qb.from_(employee).delete().where(employee.company == "_Test Company").run()
+		frappe.qb.from_("Salary Slip").delete().run()
 
 	def create_records(self):
 		self.employee = make_employee(
@@ -111,3 +109,103 @@ class TestIncomeTaxComputation(IntegrationTestCase):
 
 		for key, val in expected_data.items():
 			self.assertEqual(result[1][0].get(key), val)
+
+	def test_employee_joined_after_payroll_period_is_excluded(self):
+		# employee joins after the payroll period ends -> employment does not overlap
+		# the period, so they must be excluded from the report (and not crash it while
+		# trying to build a salary slip with no applicable salary structure)
+		joining_date = add_days(self.payroll_period.end_date, 90)
+		employee = make_employee(
+			"joined_after_period@example.com",
+			company="_Test Company",
+			date_of_joining=joining_date,
+		)
+		make_salary_structure(
+			"Monthly Salary Structure Joined After Period",
+			"Monthly",
+			employee=employee,
+			company="_Test Company",
+			currency="INR",
+			from_date=joining_date,
+			payroll_period=self.payroll_period,
+			test_tax=True,
+		)
+
+		filters = frappe._dict(
+			{
+				"company": "_Test Company",
+				"payroll_period": self.payroll_period.name,
+			}
+		)
+		result = execute(filters)[1]
+
+		employees_in_report = [row.get("employee") for row in result]
+		self.assertNotIn(employee, employees_in_report)
+
+	def test_employee_relieved_before_payroll_period_is_excluded(self):
+		# employee relieved before the payroll period starts -> employment does not
+		# overlap the period, so they must be excluded from the report
+		joining_date = add_days(self.payroll_period.start_date, -400)
+		relieving_date = add_days(self.payroll_period.start_date, -1)
+		employee = make_employee(
+			"relieved_before_period@example.com",
+			company="_Test Company",
+			date_of_joining=joining_date,
+		)
+		make_salary_structure(
+			"Monthly Salary Structure Relieved Before Period",
+			"Monthly",
+			employee=employee,
+			company="_Test Company",
+			currency="INR",
+			from_date=joining_date,
+			payroll_period=self.payroll_period,
+			test_tax=True,
+		)
+		frappe.db.set_value("Employee", employee, {"relieving_date": relieving_date, "status": "Left"})
+
+		filters = frappe._dict(
+			{
+				"company": "_Test Company",
+				"payroll_period": self.payroll_period.name,
+			}
+		)
+		result = execute(filters)[1]
+
+		employees_in_report = [row.get("employee") for row in result]
+		self.assertNotIn(employee, employees_in_report)
+
+	def test_get_report_for_all_employees(self):
+		frappe.db.delete("Employee")
+		users = [
+			{"email": "test_itrc1@example.com", "args": {"status": "Active"}},
+			{"email": "test_itrc2@example.com", "args": {"status": "Inactive"}},
+			{"email": "test_itrc3@example.com", "args": {"status": "Suspended"}},
+			{"email": "test_itrc4@example.com", "args": {"status": "Left", "relieving_date": getdate()}},
+		]
+
+		for user in users:
+			employee = make_employee(user["email"], company="_Test Company")
+			salary_structure = make_salary_structure(
+				"Monthly Salary Structure Test Income Tax Computation",
+				"Monthly",
+				employee=employee,
+				company="_Test Company",
+				currency="INR",
+				payroll_period=self.payroll_period,
+				test_tax=True,
+			)
+
+			create_salary_slips_for_payroll_period(
+				employee, salary_structure.name, self.payroll_period, deduct_random=False, num=3
+			)
+			frappe.db.set_value("Employee", employee, user["args"])
+
+		filters = frappe._dict(
+			{
+				"company": "_Test Company",
+				"payroll_period": self.payroll_period.name,
+			}
+		)
+		result = execute(filters)[1]
+		self.assertEqual(len(result), 4)

--- a/hrms/payroll/utils.py
+++ b/hrms/payroll/utils.py
@@ -1,4 +1,9 @@
+import unicodedata
+from datetime import date
+
 import frappe
+from frappe import _
+from frappe.utils import ceil, floor, get_first_day, get_last_day, get_link_to_form, getdate, rounded
 
 
 def sanitize_expression(string: str | None = None) -> str | None:
@@ -24,6 +29,139 @@ def sanitize_expression(string: str | None = None) -> str | None:
 	string = " ".join(parts)
 
 	return string
+
+
+COMPONENT_EVAL_GLOBALS = {
+	"int": int,
+	"float": float,
+	"long": int,
+	"round": round,
+	"rounded": rounded,
+	"date": date,
+	"getdate": getdate,
+	"get_first_day": get_first_day,
+	"get_last_day": get_last_day,
+	"ceil": ceil,
+	"floor": floor,
+	"min": min,
+	"max": max,
+}
+
+
+def get_component_abbr_map() -> dict:
+	"""Cached {salary_component_abbr: 0} map, seeded into the formula eval context
+	so any component abbreviation referenced in a formula resolves (default 0).
+
+	Cache key matches salary_slip.SALARY_COMPONENT_VALUES (shared entry, invalidated
+	on Salary Component save)."""
+
+	def _fetch_component_values():
+		return {abbr: 0 for abbr in frappe.get_all("Salary Component", pluck="salary_component_abbr")}
+
+	return frappe.cache().get_value("salary_component_values", generator=_fetch_component_values)
+
+
+SALARY_SLIP_EVAL_DEFAULTS = {
+	"gross_pay": 0,
+	"net_pay": 0,
+	"total_deduction": 0,
+	"rounded_total": 0,
+	"total_working_hours": 0,
+	"hour_rate": 0,
+	"year_to_date": 0,
+	"month_to_date": 0,
+	"gross_year_to_date": 0,
+	"ctc": 0,
+	"total_earnings": 0,
+	"income_from_other_sources": 0,
+	"non_taxable_earnings": 0,
+	"deductions_before_tax_calculation": 0,
+	"tax_exemption_declaration": 0,
+	"standard_tax_exemption_amount": 0,
+	"annual_taxable_amount": 0,
+	"income_tax_deducted_till_date": 0,
+	"future_income_tax_deductions": 0,
+	"current_month_income_tax": 0,
+	"total_income_tax": 0,
+}
+
+
+def get_component_eval_context(employee: str, ssa_as_dict: dict) -> frappe._dict:
+	"""Build the base evaluation context for salary component formulas.
+
+	Merges component abbreviation defaults, Salary Structure Assignment fields
+	(base, variable, ...) and employee fields so that formulas can reference any
+	of them by name.
+	"""
+	data = frappe._dict()
+	data.update(get_component_abbr_map())
+	data.update(SALARY_SLIP_EVAL_DEFAULTS)
+	data.update(ssa_as_dict)
+	data.update(frappe.get_cached_doc("Employee", employee).as_dict())
+	return data
+
+
+def _check_attributes(code: str) -> None:
+	import ast
+
+	from frappe.utils.safe_exec import UNSAFE_ATTRIBUTES
+
+	unsafe_attrs = set(UNSAFE_ATTRIBUTES).union(["__"]) - {"format"}
+
+	for attribute in unsafe_attrs:
+		if attribute in code:
+			raise SyntaxError(f'Illegal rule {frappe.bold(code)}. Cannot use "{attribute}"')
+
+	BLOCKED_NODES = (ast.NamedExpr, ast.Lambda)
+
+	tree = ast.parse(code, mode="eval")
+	for node in ast.walk(tree):
+		if isinstance(node, BLOCKED_NODES):
+			raise SyntaxError(f"Operation not allowed: line {node.lineno} column {node.col_offset}")
+		if isinstance(node, ast.Attribute) and isinstance(node.attr, str) and node.attr in UNSAFE_ATTRIBUTES:
+			raise SyntaxError(f'Illegal rule {frappe.bold(code)}. Cannot use "{node.attr}"')
+
+
+def _safe_eval(code: str, eval_globals: dict | None = None, eval_locals: dict | None = None):
+	"""Safe eval for **trusted** salary component conditions and formulas only.
+
+	Uses AST-based attribute checking instead of frappe.safe_eval to avoid
+	recursion limit issues with the large/deeply-nested formulas some countries'
+	payroll needs. It is a lighter (denylist-based) sandbox than frappe.safe_eval,
+	so it is safe only for admin-authored salary-structure formulas, not arbitrary
+	or end-user input. For anything else, use frappe.safe_eval.
+	"""
+	code = unicodedata.normalize("NFKC", code)
+
+	_check_attributes(code)
+
+	whitelisted_globals = {"int": int, "float": float, "long": int, "round": round}
+	if not eval_globals:
+		eval_globals = {}
+
+	eval_globals["__builtins__"] = {}
+	eval_globals.update(whitelisted_globals)
+	return eval(code, eval_globals, eval_locals)  # nosemgrep
+
+
+def throw_error_message(row, error, title, description=None):
+	data = frappe._dict(
+		{
+			"doctype": row.parenttype,
+			"name": row.parent,
+			"doclink": get_link_to_form(row.parenttype, row.parent),
+			"row_id": row.idx,
+			"error": error,
+			"title": title,
+			"description": description or "",
+		}
+	)
+
+	message = _(
+		"Error while evaluating the {doctype} {doclink} at row {row_id}. <br><br> <b>Error:</b> {error} <br><br> <b>Hint:</b> {description}"
+	).format(**data)
+
+	frappe.throw(message, title=title)
 
 
 @frappe.whitelist()

--- a/hrms/public/js/erpnext/payment_entry.js
+++ b/hrms/public/js/erpnext/payment_entry.js
@@ -47,11 +47,13 @@ frappe.ui.form.on("Payment Entry", {
 				filters["is_paid"] = 0;
 			}
 
-			if (
-				child.reference_doctype == "Employee Advance" ||
-				child.reference_doctype == "Leave Encashment"
-			) {filters["status"] = "Unpaid";}
+			if (child.reference_doctype == "Employee Advance") {
+				filters["status"] = ["in", ["Unpaid", "Partially Paid"]];
+			}
 
+			if (child.reference_doctype == "Leave Encashment") {
+				filters["status"] = "Unpaid";
+			}
 
 			return {
 				filters: filters,

--- a/hrms/tests/test_roster.py
+++ b/hrms/tests/test_roster.py
@@ -1,0 +1,140 @@
+import frappe
+from frappe.utils import add_days, getdate
+
+from hrms.api.roster import get_shifts, insert_shift
+from hrms.tests.utils import HRMSTestSuite
+
+
+class TestRoster(HRMSTestSuite):
+	def test_get_shifts_returns_shift_type_details(self):
+		date = getdate()
+		employee_name = f"_Test Roster Employee {frappe.generate_hash(length=8)}"
+		employee = create_employee(employee_name)
+		shift_type = create_shift_type(
+			f"_Test Roster Shift {frappe.generate_hash(length=8)}",
+			start_time="10:00:00",
+			end_time="18:00:00",
+			color="Violet",
+		)
+		shift_assignment = create_shift_assignment(shift_type.name, employee.name, date)
+
+		shifts = get_shifts(add_days(date, -1), add_days(date, 1), {"employee_name": employee_name}, {})
+
+		self.assertEqual(len(shifts[employee.name]), 1)
+		self.assertEqual(shifts[employee.name][0]["name"], shift_assignment.name)
+		self.assertEqual(str(shifts[employee.name][0]["start_time"]), "10:00:00")
+		self.assertEqual(str(shifts[employee.name][0]["end_time"]), "18:00:00")
+		self.assertEqual(shifts[employee.name][0]["color"], "Violet")
+
+	def test_insert_shift_ignores_cancelled_assignment(self):
+		"""Cancelled Shift Assignments should not block or be mutated by insert_shift."""
+		employee_name = f"_Test Roster Cancel {frappe.generate_hash(length=8)}"
+		employee = create_employee(employee_name)
+		shift_type = create_shift_type(
+			f"_Test Cancel Shift {frappe.generate_hash(length=8)}",
+			start_time="08:00:00",
+			end_time="17:00:00",
+			color="Red",
+		)
+
+		# Create a shift assignment with a date range, submit it, then cancel it
+		original = frappe.get_doc(
+			{
+				"doctype": "Shift Assignment",
+				"employee": employee.name,
+				"company": "_Test Company",
+				"shift_type": shift_type.name,
+				"start_date": "2026-07-01",
+				"end_date": "2026-07-10",
+			}
+		)
+		original.submit()
+		original.cancel()
+		original.reload()
+		self.assertEqual(original.docstatus, 2)
+		original_end_date = original.end_date
+
+		# Attempt to insert an adjacent shift (Jul 11 = day after Jul 10)
+		insert_shift(
+			employee=employee.name,
+			company="_Test Company",
+			shift_type=shift_type.name,
+			start_date="2026-07-11",
+			end_date="2026-07-20",
+			status="Active",
+		)
+
+		# The cancelled record must remain untouched
+		original.reload()
+		self.assertEqual(original.end_date, original_end_date)
+
+		# A new, non-cancelled assignment must exist for the new range
+		new_assignment = frappe.db.exists(
+			"Shift Assignment",
+			{
+				"employee": employee.name,
+				"start_date": "2026-07-11",
+				"end_date": "2026-07-20",
+				"docstatus": ["!=", 2],
+			},
+		)
+		self.assertTrue(new_assignment)
+
+
+def create_employee(employee_name: str):
+	create_company()
+	if not frappe.db.exists("Gender", "Female"):
+		frappe.get_doc({"doctype": "Gender", "gender": "Female"}).insert()
+
+	return frappe.get_doc(
+		{
+			"doctype": "Employee",
+			"first_name": employee_name,
+			"company": "_Test Company",
+			"gender": "Female",
+			"date_of_birth": "1990-01-01",
+			"date_of_joining": "2020-01-01",
+			"status": "Active",
+		}
+	).insert()
+
+
+def create_company():
+	if frappe.db.exists("Company", "_Test Company"):
+		return
+
+	frappe.get_doc(
+		{
+			"doctype": "Company",
+			"company_name": "_Test Company",
+			"default_currency": "INR",
+			"country": "India",
+		}
+	).insert()
+
+
+def create_shift_type(shift_type: str, start_time: str, end_time: str, color: str):
+	return frappe.get_doc(
+		{
+			"doctype": "Shift Type",
+			"__newname": shift_type,
+			"start_time": start_time,
+			"end_time": end_time,
+			"color": color,
+		}
+	).insert()
+
+
+def create_shift_assignment(shift_type: str, employee: str, date: str):
+	shift_assignment = frappe.get_doc(
+		{
+			"doctype": "Shift Assignment",
+			"employee": employee,
+			"company": "_Test Company",
+			"shift_type": shift_type,
+			"start_date": date,
+			"end_date": date,
+		}
+	)
+	shift_assignment.submit()
+	return shift_assignment


### PR DESCRIPTION
1. fix: salary slip preview calls
2. fix: set party_not_required flag for loan repayment GL entries when employee-based accounting is disabled
3. test: update loan repayment party assertion for payroll payable GL entry
4. test: update loan repayment party assertion for payroll payable GL entry
5. fix: set party_not_required flag for loan repayment GL entries when employee-based accounting is disabled
6. feat: add Forgot Password page.
7. fix: make reason_for_adjustment optional in create_leave_adjustment method
8. fix: pass salary slip end_date as value_date when creating loan repayment entry
9. fix: pass salary slip end_date as value_date when creating loan repayment entry
10. fix: Add component abbreviation to component name in CTC break-up report
11. fix: remove permlevel restriction from status field in shift_request
12. feat: allow employee view ctc break up of employee records they have access to
13. feat: set current employee as the deault value for filters
14. fix: on change for employee should hanlt setting the salary structure assignment too
15. fix: Deduction using additional salary with tax exempt
16. fix(goal): replace query builder with get_list to apply permission in goal tree view
17. fix: invalidate salary structure cache on document update
18. fix: correct employee incentive filter logic for Salary Component
19. fix(vehicle_log): add validation to prevent cancellation of Vehicle Log linked to Expense Claim.
20. feat: employer contribution type in salary component
21. refactor: use salary structure assignment's calculations for preview of salary slip
22. fix: filter employers contribution components in the child table
23. fix: exclude do not include in total from annual_gross_earning and include it in ctc
24. fix: rename ts_config which sounds like a typescript config file to timesheet_config
25. test: ctc and annual gross earning for salary structure based on timesheet
26. fix: move timesheet wage component calculation to salary slip
27. fix: notes, variable names and redundant function passsing
28. fix(vehicle_log): update cancellation logic to unlink Vehicle Log from submitted Expense Claims.
29. fix(vehicle_log): enhance cancellation logic to handle linked submitted and draft Expense Claims
30. fix: update shift query to use ShiftAssignment and include ShiftType fields
31. test: add integration tests for shift retrieval functionality
32. feat: add partially paid status in employee advance
33. chore: remove unwanted argument
34. fix: update pending amount in employee advance
35. fix: update partially paid status, color and pending amount handling
36. chore: update partial advance claim test to submit before assertion
37. fix: include frontend and roster in asset build
38. Revert "fix: update shift query to use ShiftAssignment and include ShiftType fields"
39. fix: update get_shifts to include ShiftType details and add unit tests for shift retrieval
40. feat(report): enhance Employee Advance Summary report
41. fix: update get_shifts to include ShiftType details and add unit tests for shift retrieval
42. fix(vehicle_log): improve cancellation logic to handle linked draft Expense Claims and update description handling
43. fix: change company names in test
44. chore: fix payroll reviewer handle in CODEOWNERS
45. fix: add salary slip to eval context
46. fix: add salary slip dates to eval context
47. fix: avoid company abbreviation collision in attendance test
48. refactor: optimize database query for payroll settings migration
49. fix: resolve socketio_port at runtime instead of bundling common_site_config.json
50. refactor(report): follow frappe/hrms conventions in Employee Advance Summary
51. refactor(report): rename balance to outstanding_amount
52. fix(report): show Title and Outstanding Amount in flat view
53. fix(report): show employee name in group header when grouping by Employee
54. feat(report): show employee ID and name together in Employee column and group header
55. refactor(report): use filters.get() and scrub() inline for group_by
56. fix: pass apps.json to image build via secret mount
57. fix: package frontend and roster assets from public dir
58. fix(vehicle_log): handle error in before_cancel promise rejection
59. fix(expense-claim): convert advance amounts to the claim currency
60. fix(expense-claim): filter advances by claim currency
61. fix: add permission check for allocate_leaves_manually
62. fix: add permission check for half-day attendance updates
63. fix: add permission check for insert_shift mutations
64. fix: guard raw query builder update inside permission block
65. fix: add delete permission check for next_shift
66. fix: scope qb.update to the exact attendance_name validated by permission check
67. fix: filter attendance lookup to submitted records (docstatus=1)
68. fix: use frappe.db.set_value to preserve audit trail on half-day update
69. fix: remove ignore permission parameter from whiltelisted method
70. fix: filter employees in the selected payroll period for income tax report
71. refactor(vehicle_log): remove rows with the Vehicle Expenses description and cancellation message changed
72. fix(employee_leave_balance): include carry forwarded leaves in allocation calculations and add related test case
73. fix(employee_payment_entry): set source exchange rate on payment entry creation to avoid empty exchange gain/loss account error
74. test: verify no exchange gain/loss triggered for same currency advance payment
75. refactor(employee_leave_balance): refine opening balance calculation to include allocation boundary condition
76. feat: show employer contributions in CTC breakup report
77. test: formula based employer contribution
78. test: add tests to assert earned leave schedule based on leave period and joining date
79. test: remove current date flag
80. fix: permission check for whitelisted methods
81. fix: filter expense account by company and root type in leave encashment
82. feat: add payment entry connection to leave encashment
83. test: Add endpoint tests
84. feat: Add regional hooks
85. ci: review translation PRs
86. test: Simulate actual payment entry doc
87. fix: warnings thrown to the user during setup
88. test(attendance): add regression test for half-day permission check
89. test(attendance): fix regression test CI issues
90. fix(attendance): prevalidate permissions before batch update
91. test: ensure attendance is reloaded before permission check
92. fix: resolve test isolation/regression causing CI failures
93. fix: implement close warning for job openings and related validation.
94. fix(pwa): preserve link field value when value is outside default options
95. fix(income_tax_computation): use taxable earnings till date only when Salary Structure Assignment is within payroll period